### PR TITLE
Add SecurityAdvisory classification for GitHub Advisory

### DIFF
--- a/open-vulnerability-clients/build.gradle
+++ b/open-vulnerability-clients/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2'
     implementation 'com.samskivert:jmustache:1.15'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 }
 
 publishing {

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
@@ -118,6 +118,10 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
      */
     private String githubToken;
     /**
+     * The classification of the advisory ("GENERAL", "MALWARE")
+     */
+    private String classifications;
+    /**
      * The updatedSince filter.
      */
     private String updatedSinceFilter;
@@ -177,6 +181,15 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
             throw new GitHubSecurityAdvisoryException(e);
         }
         return Mustache.compiler().escapeHTML(false).compile(template);
+    }
+
+    /**
+     * The classification of the advisory ("GENERAL", "MALWARE")
+     *
+     * @param classifications the classification of the advisory.
+     */
+    public void setClassifications(String classifications) {
+        this.classifications = classifications;
     }
 
     /**
@@ -321,6 +334,9 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
 
     private Map<String, String> buildGraphQLData() {
         Map<String, String> data = new HashMap<String, String>();
+        if (classifications != null) {
+            data.put("classifications", classifications);
+        }
         if (updatedSinceFilter != null) {
             data.put("updatedSince", updatedSinceFilter);
         }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
@@ -28,18 +28,11 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
-import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
-import org.apache.hc.core5.function.Factory;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
-import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLEngine;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
@@ -349,7 +349,7 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
     /**
      * Returns the latest updated date.
      *
-     * @return the lastest updated date
+     * @return the latest updated date
      */
     public ZonedDateTime getLastUpdated() {
         return lastUpdated;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClientBuilder.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClientBuilder.java
@@ -48,6 +48,11 @@ public final class GitHubSecurityAdvisoryClientBuilder {
      * The endpoint for the GitHub GraphQL API.
      */
     private String endpoint;
+
+    /**
+     * The classification of the advisory ("GENERAL", "MALWARE")
+     */
+    private String classifications;
     /**
      * The updatedSince filter.
      */
@@ -95,6 +100,17 @@ public final class GitHubSecurityAdvisoryClientBuilder {
     }
 
     /**
+     * The classification of the advisory ("GENERAL", "MALWARE")
+     *
+     * @param classifications the classification of the advisory
+     * @return the builder
+     */
+    public GitHubSecurityAdvisoryClientBuilder withClassifications(String classifications) {
+        this.classifications = classifications;
+        return this;
+    }
+
+    /**
      * Filter for Security Advisories that have been updated since a specific date/time.
      *
      * @param utcUpdatedSince the UTC date time
@@ -127,6 +143,9 @@ public final class GitHubSecurityAdvisoryClientBuilder {
             client = new GitHubSecurityAdvisoryClient(apiKey);
         } else {
             client = new GitHubSecurityAdvisoryClient(apiKey, endpoint);
+        }
+        if (classifications != null) {
+            client.setClassifications(classifications);
         }
         if (publishedSince != null) {
             client.setPublishedSinceFilter(publishedSince);

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"databaseId", "description", "ghsaId", "id", "identifiers", "notificationsPermalink", "origin",
-        "permalink", "publishedAt", "references", "severity", "summary", "updatedAt", "vulnerabilities", "cvss", "cwes",
+        "permalink", "publishedAt", "references", "severity", "summary", "updatedAt", "vulnerabilities", "classification", "cvss", "cwes",
         "withdrawnAt"})
 public class SecurityAdvisory {
 
@@ -76,6 +76,9 @@ public class SecurityAdvisory {
     @JsonProperty("withdrawnAt")
     @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ssX", timezone = "UTC")
     private ZonedDateTime withdrawnAt;
+
+    @JsonProperty("classification")
+    private String classification;
 
     @JsonProperty("cvss")
     private CVSS cvss;
@@ -217,6 +220,15 @@ public class SecurityAdvisory {
     }
 
     /**
+     * The classification of the advisory. type, e.g. GENERAL, MALWARE.
+     *
+     * @return the classification of the advisory.
+     */
+    public String getClassification() {
+        return classification;
+    }
+
+    /**
      * The CVSS associated with this advisory.
      *
      * @return the CVSS associated with this advisory.
@@ -254,7 +266,7 @@ public class SecurityAdvisory {
                 + notificationsPermalink + '\'' + ", origin='" + origin + '\'' + ", permalink='" + permalink + '\''
                 + ", publishedAt=" + publishedAt + ", references=" + references + ", severity=" + severity
                 + ", summary='" + summary + '\'' + ", updatedAt=" + updatedAt + ", withdrawnAt=" + withdrawnAt
-                + ", cvss=" + cvss + ", cwes=" + cwes + ", vulnerabilities=" + vulnerabilities + '}';
+                + ", classification=" + classification + ", cvss=" + cvss + ", cwes=" + cwes + ", vulnerabilities=" + vulnerabilities + '}';
     }
 
     @Override
@@ -272,6 +284,7 @@ public class SecurityAdvisory {
                 && Objects.equals(publishedAt, that.publishedAt) && Objects.equals(references, that.references)
                 && severity == that.severity && Objects.equals(summary, that.summary)
                 && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(withdrawnAt, that.withdrawnAt)
+                && Objects.equals(classification, that.classification)
                 && Objects.equals(cvss, that.cvss) && Objects.equals(cwes, that.cwes)
                 && Objects.equals(vulnerabilities, that.vulnerabilities);
     }
@@ -279,6 +292,6 @@ public class SecurityAdvisory {
     @Override
     public int hashCode() {
         return Objects.hash(databaseId, description, ghsaId, id, identifiers, notificationsPermalink, origin, permalink,
-                publishedAt, references, severity, summary, updatedAt, withdrawnAt, cvss, cwes, vulnerabilities);
+                publishedAt, references, severity, summary, updatedAt, withdrawnAt, classification, cvss, cwes, vulnerabilities);
     }
 }

--- a/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
+++ b/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
@@ -50,6 +50,7 @@ query {
           endCursor
         }
       }
+      classification
       cvss {
         score
         vectorString

--- a/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
+++ b/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
@@ -9,7 +9,9 @@ query {
       orderBy: {field: UPDATED_AT, direction: ASC}
       {{#updatedSince}}updatedSince: "{{updatedSince}}" {{/updatedSince}}
       {{#publishedSince}}publishedSince: "{{publishedSince}}" {{/publishedSince}}
-      {{#after}}after: "{{after}}" {{/after}} ) {
+      {{#classifications}}classifications: {{classifications}} {{/classifications}}
+      {{#after}}after: "{{after}}" {{/after}}
+  ) {
     nodes {
       databaseId
       description

--- a/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClientTest.java
+++ b/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClientTest.java
@@ -25,8 +25,6 @@ import org.slf4j.LoggerFactory;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 class GitHubSecurityAdvisoryClientTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSecurityAdvisoryClientTest.class);

--- a/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/ghsa/SerializationTest.java
+++ b/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/ghsa/SerializationTest.java
@@ -25,10 +25,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SerializationTest {
 
@@ -40,7 +40,7 @@ public class SerializationTest {
 
         String json;
         try (BufferedReader r = new BufferedReader(new InputStreamReader(
-                this.getClass().getClassLoader().getResourceAsStream("advisories.json"), StandardCharsets.UTF_8))) {
+                Objects.requireNonNull(this.getClass().getClassLoader().getResourceAsStream("advisories.json")), StandardCharsets.UTF_8))) {
             json = r.lines().collect(Collectors.joining("\n"));
         }
         SecurityAdvisories current = objectMapper.readValue(json, SecurityAdvisories.class);
@@ -49,7 +49,7 @@ public class SerializationTest {
         String serialized = objectMapper.writeValueAsString(current);
         SecurityAdvisories hydrated = objectMapper.readValue(serialized, SecurityAdvisories.class);
         String reserialized = objectMapper.writeValueAsString(hydrated);
-        assertTrue(serialized.equals(reserialized));
+        assertEquals(serialized, reserialized);
 
     }
 }

--- a/open-vulnerability-clients/src/test/resources/advisories.json
+++ b/open-vulnerability-clients/src/test/resources/advisories.json
@@ -114,7 +114,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 1276,
@@ -208,7 +209,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 2660,
@@ -309,7 +311,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 2315,
@@ -380,7 +383,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 197913,
@@ -471,7 +475,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 179004,
@@ -561,7 +566,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 185990,
@@ -641,7 +647,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 191238,
@@ -738,7 +745,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 195572,
@@ -809,7 +817,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         },
         {
           "databaseId": 994,
@@ -889,7 +898,8 @@
               "hasPreviousPage": false
             }
           },
-          "withdrawnAt": null
+          "withdrawnAt": null,
+          "classification": "GENERAL"
         }
       ],
       "totalCount": 11289,

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/GHSACommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/GHSACommand.java
@@ -36,6 +36,7 @@ import picocli.CommandLine;
 
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.Objects;
 
 import static com.diogonunes.jcolor.Ansi.colorize;
 
@@ -55,6 +56,9 @@ public class GHSACommand extends AbstractJsonCommand {
     @CommandLine.Option(names = {
             "--publishedSince"}, description = "The UTC date/time to filter advisories that were published since the given date")
     private ZonedDateTime publishedSince;
+    @CommandLine.Option(names = {
+            "--classifications"}, description = "The classification of the advisory (\"GENERAL\", \"MALWARE\")")
+    private String classifications;
     // yes - this should not be a string, but seriously down the call path the HttpClient
     // doesn't support passing a header in as a char[]...
     private String apiKey = null;
@@ -98,6 +102,9 @@ public class GHSACommand extends AbstractJsonCommand {
         }
         if (updatedSince != null) {
             builder.withUpdatedSinceFilter(updatedSince);
+        }
+        if (classifications != null) {
+            builder.withClassifications(classifications);
         }
 
         ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
Add SecurityAdvisory `classification` for GitHub Advisory.
https://docs.github.com/en/graphql/reference/objects#securityadvisory

```bash
# same results
$ ./vulnz/build/libs/vulnz-4.0.1.jar ghsa --updatedSince="2023-05-01T00:00:00Z" > result.json
$ ./vulnz/build/libs/vulnz-4.0.1.jar ghsa --updatedSince="2023-05-01T00:00:00Z" --classifications="GENERAL" > result1.json

# MALWARE only
$ ./vulnz/build/libs/vulnz-4.0.1.jar ghsa --updatedSince="2023-05-01T00:00:00Z" --classifications="MALWARE" > result.json
```

[result.json.txt](https://github.com/jeremylong/Open-Vulnerability-Project/files/11396701/result.json.txt)
[result2.json.txt](https://github.com/jeremylong/Open-Vulnerability-Project/files/11396703/result2.json.txt)

