### PR TITLE
fix: Make POJOs Seriializable

### DIFF
--- a/buildSrc/src/main/groovy/vuln.tools.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/vuln.tools.java-common-conventions.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'io.github.jeremylong'
-version = '5.0.0'
+version = '5.0.1'
 
 repositories {
     mavenCentral()

--- a/open-vulnerability-clients/README.md
+++ b/open-vulnerability-clients/README.md
@@ -39,14 +39,14 @@ See API usage examples in the [open-vulnerability-store](https://github.com/jere
 <dependency>
    <groupId>io.github.jeremylong</groupId>
    <artifactId>open-vulnerability-clients</artifactId>
-   <version>5.0.0</version>
+   <version>5.0.1</version>
 </dependency>
 ```
 
 ### gradle
 
 ```groovy
-implementation 'io.github.jeremylong:open-vulnerability-clients:5.0.0'
+implementation 'io.github.jeremylong:open-vulnerability-clients:5.0.1'
 ```
 
 ### api usage

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/DataFeed.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/DataFeed.java
@@ -16,8 +16,6 @@
  */
 package io.github.jeremylong.openvulnerability.client;
 
-import java.util.List;
-
 public interface DataFeed<T> {
-    public T download();
+    T download();
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/PagedDataSource.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/PagedDataSource.java
@@ -28,21 +28,21 @@ public interface PagedDataSource<T> extends AutoCloseable, Iterator<Collection<T
      * @throws Exception thrown if there is a problem.
      */
     @Override
-    public void close() throws Exception;
+    void close() throws Exception;
 
     /**
      * Only available after the first call to `next()`; returns the total number of records that will be available.
      *
      * @return the total number of records that will be returned
      */
-    public int getTotalAvailable();
+    int getTotalAvailable();
 
     /**
      * Returns the last HTTP Status Code received.
      *
      * @return the last HTTP Status Code received.
      */
-    public int getLastStatusCode();
+    int getLastStatusCode();
 
     /**
      * Returns <code>true</code> if there are more records available; otherwise <code>false</code>.
@@ -50,7 +50,7 @@ public interface PagedDataSource<T> extends AutoCloseable, Iterator<Collection<T
      * @return <code>true</code> if there are more records available; otherwise <code>false</code>.
      */
     @Override
-    public boolean hasNext();
+    boolean hasNext();
 
     /**
      * Returns the next collection of vulnerability data.
@@ -58,13 +58,13 @@ public interface PagedDataSource<T> extends AutoCloseable, Iterator<Collection<T
      * @return a collection of vulnerability data.
      */
     @Override
-    public Collection<T> next();
+    Collection<T> next();
 
     /**
      * Returns the latest updated date.
      *
      * @return the latest updated date
      */
-    public ZonedDateTime getLastUpdated();
+    ZonedDateTime getLastUpdated();
 
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/RecordDataSource.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/RecordDataSource.java
@@ -21,13 +21,13 @@ import java.util.Collection;
 import java.util.Iterator;
 
 /**
- * A simple wrapper around a PagedDataSource that iterates over single objects rather then a page at a time.
+ * A simple wrapper around a PagedDataSource that iterates over single objects rather than a page at a time.
  *
  * @param <T> the data type
  */
 public class RecordDataSource<T> implements AutoCloseable, Iterator<T> {
 
-    private PagedDataSource<T> source;
+    private final PagedDataSource<T> source;
     private Iterator<T> current;
 
     public RecordDataSource(PagedDataSource<T> source) {

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssDataFeed.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssDataFeed.java
@@ -34,7 +34,8 @@ import java.util.List;
  */
 public class EpssDataFeed implements DataFeed<List<EpssItem>> {
     private final static String DEFAULT_LOCATION = "https://epss.cyentia.com/epss_scores-current.csv.gz";
-    private String downloadUrl;
+
+    private final String downloadUrl;
 
     public EpssDataFeed() {
         this.downloadUrl = DEFAULT_LOCATION;
@@ -49,7 +50,7 @@ public class EpssDataFeed implements DataFeed<List<EpssItem>> {
         List<EpssItem> list = null;
         HttpGet request = new HttpGet(downloadUrl);
         SystemDefaultRoutePlanner planner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
-        try (CloseableHttpClient client = HttpClientBuilder.create().setRoutePlanner(planner).build();) {
+        try (CloseableHttpClient client = HttpClientBuilder.create().setRoutePlanner(planner).build()) {
             list = client.execute(request, new EpssResponseHandler());
         } catch (IOException e) {
             e.printStackTrace();

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssException.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssException.java
@@ -22,6 +22,12 @@ package io.github.jeremylong.openvulnerability.client.epss;
  * @author Jeremy Long
  */
 public class EpssException extends RuntimeException {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 6042021783700299275L;
+
     /**
      * Generate a new exception.
      *

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssItem.java
@@ -29,6 +29,10 @@ import java.io.Serializable;
 
 @JsonPropertyOrder({"cve", "epss", "percentile"})
 public class EpssItem implements Serializable {
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 5043194930534860395L;
     @JsonProperty("cve")
     String cve;
     @JsonProperty("epss")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssItem.java
@@ -16,9 +16,10 @@
  */
 package io.github.jeremylong.openvulnerability.client.epss;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.io.Serializable;
 
 /**
  * Exploit Prediction Scoring System (EPSS) score.
@@ -27,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 
 @JsonPropertyOrder({"cve", "epss", "percentile"})
-public class EpssItem {
+public class EpssItem implements Serializable {
     @JsonProperty("cve")
     String cve;
     @JsonProperty("epss")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssResponseHandler.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssResponseHandler.java
@@ -57,7 +57,7 @@ public class EpssResponseHandler extends AbstractHttpClientResponseHandler<List<
                 }
                 try {
                     String[] data = line.split(",");
-                    EpssItem score = new EpssItem(data[0], new Double(data[1]), new Double(data[2]));
+                    EpssItem score = new EpssItem(data[0], Double.parseDouble(data[1]), Double.parseDouble((data[2]));
                     list.add(score);
                 } catch (NumberFormatException | ArrayIndexOutOfBoundsException ex) {
                     throw new EpssException("Unable to parse EPSS CSV", ex);

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssResponseHandler.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssResponseHandler.java
@@ -57,7 +57,7 @@ public class EpssResponseHandler extends AbstractHttpClientResponseHandler<List<
                 }
                 try {
                     String[] data = line.split(",");
-                    EpssItem score = new EpssItem(data[0], Double.parseDouble(data[1]), Double.parseDouble((data[2]));
+                    EpssItem score = new EpssItem(data[0], Double.parseDouble(data[1]), Double.parseDouble((data[2])));
                     list.add(score);
                 } catch (NumberFormatException | ArrayIndexOutOfBoundsException ex) {
                     throw new EpssException("Unable to parse EPSS CSV", ex);

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/AbstractPageable.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/AbstractPageable.java
@@ -20,8 +20,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AbstractPageable {
+public class AbstractPageable implements Serializable {
 
     @JsonProperty(value = "totalCount", access = JsonProperty.Access.WRITE_ONLY)
     private int totalCount;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/AbstractPageable.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/AbstractPageable.java
@@ -25,6 +25,10 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AbstractPageable implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 7420520124100919177L;
     @JsonProperty(value = "totalCount", access = JsonProperty.Access.WRITE_ONLY)
     private int totalCount;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSS.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSS.java
@@ -35,6 +35,10 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CVSS implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 7546185855105761759L;
     @JsonProperty("score")
     Double score;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSS.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSS.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -32,7 +33,7 @@ import java.util.Objects;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class CVSS {
+public class CVSS implements Serializable {
 
     @JsonProperty("score")
     Double score;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWE.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWE.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -27,7 +28,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"cweId", "name", "description"})
-public class CWE {
+public class CWE implements Serializable {
 
     @JsonProperty(value = "node", access = JsonProperty.Access.WRITE_ONLY)
     private CWERecord node;
@@ -120,7 +121,7 @@ public class CWE {
      * </pre>
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class CWERecord {
+    static class CWERecord implements Serializable {
 
         @JsonProperty("cweId")
         private String cweId;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWE.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWE.java
@@ -30,6 +30,10 @@ import java.util.Objects;
 @JsonPropertyOrder({"cweId", "name", "description"})
 public class CWE implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -5061078131276736530L;
     @JsonProperty(value = "node", access = JsonProperty.Access.WRITE_ONLY)
     private CWERecord node;
 
@@ -123,6 +127,10 @@ public class CWE implements Serializable {
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class CWERecord implements Serializable {
 
+        /**
+         * Serialization version UID.
+         */
+        private static final long serialVersionUID = 8882754946152269822L;
         @JsonProperty("cweId")
         private String cweId;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWEs.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWEs.java
@@ -26,6 +26,10 @@ import java.util.Objects;
 
 public class CWEs extends AbstractPageable implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 1810814451811673122L;
     @JsonProperty("edges")
     private List<CWE> cwes;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWEs.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CWEs.java
@@ -20,10 +20,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
-public class CWEs extends AbstractPageable {
+public class CWEs extends AbstractPageable implements Serializable {
 
     @JsonProperty("edges")
     private List<CWE> cwes;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClient.java
@@ -112,11 +112,11 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
     /**
      * The GitHub GraphQL endpoint.
      */
-    private String endpoint;
+    private final String endpoint;
     /**
      * The GitHub Access Token.
      */
-    private String githubToken;
+    private final String githubToken;
     /**
      * The classification of the advisory ("GENERAL", "MALWARE")
      */
@@ -171,7 +171,7 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
      * @return the mustache template.
      */
     private Template loadMustacheTemplate(String resourceName) {
-        String template = null;
+        String template;
         try (InputStream is = getClass().getClassLoader().getResourceAsStream(resourceName);
                 InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
                 BufferedReader reader = new BufferedReader(isr)) {
@@ -221,11 +221,11 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
     private Future<SimpleHttpResponse> query(String json) {
         ObjectNode jsonObj = objectMapper.createObjectNode();
         jsonObj.put("query", json);
-        String query = null;
+        String query;
         try {
             query = objectMapper.writeValueAsString(jsonObj);
         } catch (JsonProcessingException e) {
-            throw new GitHubSecurityAdvisoryException("Unable to convert template to quer", e);
+            throw new GitHubSecurityAdvisoryException("Unable to convert template to query", e);
         }
         SimpleRequestBuilder builder = SimpleRequestBuilder.post(endpoint);
         builder.addHeader("Authorization", "bearer " + githubToken);
@@ -287,13 +287,11 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
     public Collection<SecurityAdvisory> next() {
         try {
             Map<String, String> data = buildGraphQLData();
-            // after should be the endCursor of the previous request - leave out for the first request
-            // data.put("after","asdfadfasdfasfawefqwe");
             if (firstCall) {
                 firstCall = false;
                 futureResponse = query(advistoriesTemplate.execute(data));
             }
-            SimpleHttpResponse response = null;
+            SimpleHttpResponse response;
             response = futureResponse.get();
             if (response.getCode() == 200) {
                 String body = response.getBodyText();
@@ -333,7 +331,7 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
     }
 
     private Map<String, String> buildGraphQLData() {
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         if (classifications != null) {
             data.put("classifications", classifications);
         }
@@ -375,14 +373,14 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
     /**
      * Ensure that the CWE and Vulnerability lists have been completely fetched and requests any missing entries.
      *
-     * @param list the list of security advisories to validate and if necassary add CWE or vulnerability data.
+     * @param list the list of security advisories to validate and if necessary add CWE or vulnerability data.
      * @throws ExecutionException thrown if there is a problem.
      * @throws InterruptedException thrown if interrupted.
      */
     private void ensureSubPages(List<SecurityAdvisory> list) throws ExecutionException, InterruptedException {
         for (SecurityAdvisory sa : list) {
             if (sa.getCwes().getPageInfo().isHasNextPage() || sa.getCwes().getTotalCount() > 50) {
-                LOG.debug("Retrieiving additional CWEs for " + sa.getGhsaId());
+                LOG.debug("Retrieving additional CWEs for " + sa.getGhsaId());
                 int count = 50;
                 int max = sa.getCwes().getTotalCount();
                 String after = sa.getCwes().getPageInfo().getEndCursor();
@@ -397,7 +395,7 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
             }
             if (sa.getVulnerabilities().getPageInfo().isHasNextPage()
                     || sa.getVulnerabilities().getTotalCount() > 100) {
-                LOG.debug("Retrieiving additional Vulnerabilities for " + sa.getGhsaId());
+                LOG.debug("Retrieving additional Vulnerabilities for " + sa.getGhsaId());
                 int count = 100;
                 int max = sa.getVulnerabilities().getTotalCount();
                 String after = sa.getVulnerabilities().getPageInfo().getEndCursor();
@@ -407,7 +405,7 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
                     count += vulnerability.getEdges().size();
                     max = vulnerability.getTotalCount();
                     after = vulnerability.getPageInfo().getEndCursor();
-                    sa.getVulnerabilities().addAllVulnerabilties(vulnerability.getEdges());
+                    sa.getVulnerabilities().addAllVulnerabilities(vulnerability.getEdges());
                 }
             }
         }
@@ -425,9 +423,9 @@ public class GitHubSecurityAdvisoryClient implements PagedDataSource<SecurityAdv
      */
     private SecurityAdvisoryResponse fetch(Template template, String ghsaId, String after)
             throws InterruptedException, ExecutionException {
-        SecurityAdvisoryResponse results = null;
+        SecurityAdvisoryResponse results;
         try {
-            Map<String, String> data = new HashMap<String, String>();
+            Map<String, String> data = new HashMap<>();
             data.put("ghsaId", ghsaId);
             data.put("after", after);
             Future<SimpleHttpResponse> future = query(template.execute(data));

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClientBuilder.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryClientBuilder.java
@@ -23,7 +23,7 @@ import java.time.ZonedDateTime;
 
 /**
  * Used to build an GitHub SecurityAdvisory GraphQL API client. As the GitHubSecurityAdvisoryClient client is
- * autoclosable the builder should be used in a try with resources:
+ * autocloseable the builder should be used in a try with resources:
  *
  * <pre>
  * try (GitHubSecurityAdvisoryClient api = GitHubSecurityAdvisoryClientBuilder.aGitHubSecurityAdvisoryClient()

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryException.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/GitHubSecurityAdvisoryException.java
@@ -23,6 +23,11 @@ package io.github.jeremylong.openvulnerability.client.ghsa;
  */
 public class GitHubSecurityAdvisoryException extends RuntimeException {
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -6615518803518244886L;
+
+    /**
      * Generate a new exception.
      *
      * @param message the message

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Identifier.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Identifier.java
@@ -34,6 +34,10 @@ import java.util.Objects;
 @JsonPropertyOrder({"type", "value"})
 public class Identifier implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 2677992599612907844L;
     @JsonProperty("type")
     private String type;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Identifier.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Identifier.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -31,7 +32,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"type", "value"})
-public class Identifier {
+public class Identifier implements Serializable {
 
     @JsonProperty("type")
     private String type;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Package.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Package.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -31,7 +32,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"ecosystem", "name"})
-public class Package {
+public class Package implements Serializable {
 
     @JsonProperty("ecosystem")
     private String ecosystem;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Package.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Package.java
@@ -34,6 +34,10 @@ import java.util.Objects;
 @JsonPropertyOrder({"ecosystem", "name"})
 public class Package implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -2621050823818486600L;
     @JsonProperty("ecosystem")
     private String ecosystem;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PackageVersion.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PackageVersion.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -30,7 +31,7 @@ import java.util.Objects;
  * </pre>
  */
 @JsonInclude(Include.NON_NULL)
-public class PackageVersion {
+public class PackageVersion implements Serializable {
 
     @JsonProperty("identifier")
     java.lang.String identifier;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PackageVersion.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PackageVersion.java
@@ -33,6 +33,10 @@ import java.util.Objects;
 @JsonInclude(Include.NON_NULL)
 public class PackageVersion implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -4943323442084443993L;
     @JsonProperty("identifier")
     java.lang.String identifier;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PageInfo.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PageInfo.java
@@ -19,6 +19,7 @@ package io.github.jeremylong.openvulnerability.client.ghsa;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -29,7 +30,7 @@ import java.util.Objects;
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PageInfo {
+public class PageInfo implements Serializable {
 
     @JsonProperty("edgeshasNextPage")
     private boolean hasNextPage;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PageInfo.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/PageInfo.java
@@ -32,6 +32,10 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PageInfo implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 3732350657963712960L;
     @JsonProperty("edgeshasNextPage")
     private boolean hasNextPage;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/RateLimit.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/RateLimit.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
@@ -31,7 +32,7 @@ import java.util.Objects;
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class RateLimit {
+public class RateLimit implements Serializable {
 
     @JsonProperty("limit")
     private int limit;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/RateLimit.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/RateLimit.java
@@ -34,6 +34,10 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RateLimit implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 1073162886358976399L;
     @JsonProperty("limit")
     private int limit;
 
@@ -48,7 +52,7 @@ public class RateLimit implements Serializable {
     private ZonedDateTime resetAt;// : 2023-02-11T14:04:20Z
 
     /**
-     * The maximum number of points the client is permitted to consume in a 60 minute window.
+     * The maximum number of points the client is permitted to consume in a 60-minute window.
      *
      * @return the limit.
      */

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Reference.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Reference.java
@@ -19,6 +19,7 @@ package io.github.jeremylong.openvulnerability.client.ghsa;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -29,7 +30,7 @@ import java.util.Objects;
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Reference {
+public class Reference implements Serializable {
 
     @JsonProperty("url")
     private String url;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Reference.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Reference.java
@@ -32,6 +32,10 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Reference implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 1985278256776999313L;
     @JsonProperty("url")
     private String url;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisories.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisories.java
@@ -27,6 +27,10 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SecurityAdvisories implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -7829868528353680425L;
     @JsonProperty(value = "data", access = JsonProperty.Access.WRITE_ONLY)
     private Data data;
 
@@ -117,6 +121,10 @@ public class SecurityAdvisories implements Serializable {
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class Data implements Serializable {
+        /**
+         * Serialization version UID.
+         */
+        private static final long serialVersionUID = 4441909076655785290L;
         @JsonProperty("rateLimit")
         private RateLimit rateLimit;
         @JsonProperty("securityAdvisories")
@@ -150,6 +158,10 @@ public class SecurityAdvisories implements Serializable {
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class Advisories extends AbstractPageable implements Serializable {
 
+        /**
+         * Serialization version UID.
+         */
+        private static final long serialVersionUID = 9126577085167634044L;
         @JsonProperty("nodes")
         private List<SecurityAdvisory> nodes;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisories.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisories.java
@@ -20,11 +20,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SecurityAdvisories {
+public class SecurityAdvisories implements Serializable {
 
     @JsonProperty(value = "data", access = JsonProperty.Access.WRITE_ONLY)
     private Data data;
@@ -115,7 +116,7 @@ public class SecurityAdvisories {
      * Internal data object.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class Data {
+    static class Data implements Serializable {
         @JsonProperty("rateLimit")
         private RateLimit rateLimit;
         @JsonProperty("securityAdvisories")
@@ -147,7 +148,7 @@ public class SecurityAdvisories {
      * internal security advisories.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class Advisories extends AbstractPageable {
+    static class Advisories extends AbstractPageable implements Serializable {
 
         @JsonProperty("nodes")
         private List<SecurityAdvisory> nodes;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
@@ -33,6 +33,11 @@ import java.util.Objects;
         "classification", "cvss", "cwes", "withdrawnAt"})
 public class SecurityAdvisory implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -2165773800065764867L;
+
     @JsonProperty("databaseId")
     private int databaseId;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -30,7 +31,7 @@ import java.util.Objects;
 @JsonPropertyOrder({"databaseId", "description", "ghsaId", "id", "identifiers", "notificationsPermalink", "origin",
         "permalink", "publishedAt", "references", "severity", "summary", "updatedAt", "vulnerabilities",
         "classification", "cvss", "cwes", "withdrawnAt"})
-public class SecurityAdvisory {
+public class SecurityAdvisory implements Serializable {
 
     @JsonProperty("databaseId")
     private int databaseId;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisoryResponse.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisoryResponse.java
@@ -27,7 +27,12 @@ import java.util.Objects;
  * Internal class used to gather additional vulnerabilities if a security advisory has more than 100 entries.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-class SecurityAdvisoryResponse {
+class SecurityAdvisoryResponse implements Serializable {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 8674460088378561016L;
 
     @JsonProperty("data")
     private Data data;
@@ -78,6 +83,12 @@ class SecurityAdvisoryResponse {
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class Data implements Serializable {
+
+        /**
+         * Serialization version UID.
+         */
+        private static final long serialVersionUID = 2397807130637898816L;
+
         @JsonProperty("rateLimit")
         private RateLimit rateLimit;
         @JsonProperty("securityAdvisory")
@@ -109,6 +120,11 @@ class SecurityAdvisoryResponse {
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class SecurityAdvisories implements Serializable {
+
+        /**
+         * Serialization version UID.
+         */
+        private static final long serialVersionUID = 8768713070922340781L;
 
         @JsonProperty("nodes")
         private List<SecurityAdvisory> nodes;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisoryResponse.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisoryResponse.java
@@ -19,6 +19,7 @@ package io.github.jeremylong.openvulnerability.client.ghsa;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
@@ -76,7 +77,7 @@ class SecurityAdvisoryResponse {
      * Internal data object.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class Data {
+    static class Data implements Serializable {
         @JsonProperty("rateLimit")
         private RateLimit rateLimit;
         @JsonProperty("securityAdvisory")
@@ -107,7 +108,7 @@ class SecurityAdvisoryResponse {
      * internal security advisories.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class SecurityAdvisories {
+    static class SecurityAdvisories implements Serializable {
 
         @JsonProperty("nodes")
         private List<SecurityAdvisory> nodes;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SimpleFutureResponse.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SimpleFutureResponse.java
@@ -32,8 +32,6 @@ class SimpleFutureResponse implements FutureCallback<SimpleHttpResponse> {
 
     @Override
     public void completed(SimpleHttpResponse result) {
-        // String response = result.getBodyText();
-        // log.debug("response::{}", response);
     }
 
     @Override

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerabilities.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerabilities.java
@@ -21,11 +21,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Vulnerabilities extends AbstractPageable {
+public class Vulnerabilities extends AbstractPageable implements Serializable {
 
     @JsonProperty("edges")
     private List<Vulnerability> vulnerabilities;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerabilities.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerabilities.java
@@ -28,6 +28,11 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Vulnerabilities extends AbstractPageable implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 8316863821743858477L;
+
     @JsonProperty("edges")
     private List<Vulnerability> vulnerabilities;
 
@@ -38,7 +43,7 @@ public class Vulnerabilities extends AbstractPageable implements Serializable {
         return vulnerabilities;
     }
 
-    boolean addAllVulnerabilties(List<Vulnerability> v) {
+    boolean addAllVulnerabilities(List<Vulnerability> v) {
         return vulnerabilities.addAll(v);
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerability.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerability.java
@@ -35,6 +35,10 @@ import java.util.Objects;
 @JsonPropertyOrder({"severity", "updatedAt", "firstPatchedVersion", "vulnerableVersionRange", "package"})
 public class Vulnerability implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -7379296334249178368L;
     @JsonProperty(value = "node", access = JsonProperty.Access.WRITE_ONLY)
     private VulnerabilityRecord node;
 
@@ -205,6 +209,12 @@ public class Vulnerability implements Serializable {
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class VulnerabilityRecord implements Serializable {
+
+        /**
+         * Serialization version UID.
+         */
+        private static final long serialVersionUID = -3820979074950827855L;
+
         @JsonProperty("firstPatchedVersion")
         private PackageVersion firstPatchedVersion;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerability.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Vulnerability.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
@@ -32,7 +33,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"severity", "updatedAt", "firstPatchedVersion", "vulnerableVersionRange", "package"})
-public class Vulnerability {
+public class Vulnerability implements Serializable {
 
     @JsonProperty(value = "node", access = JsonProperty.Access.WRITE_ONLY)
     private VulnerabilityRecord node;
@@ -203,7 +204,7 @@ public class Vulnerability {
      * </pre>
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class VulnerabilityRecord {
+    static class VulnerabilityRecord implements Serializable {
         @JsonProperty("firstPatchedVersion")
         private PackageVersion firstPatchedVersion;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevCatalog.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevCatalog.java
@@ -21,11 +21,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
 
 @JsonPropertyOrder({"cve", "epss", "percentile"})
-public class KevCatalog {
+public class KevCatalog implements Serializable {
     @JsonProperty("vulnerabilities")
     List<KevItem> vulnerabilities;
     @JsonProperty("title")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevCatalog.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevCatalog.java
@@ -27,6 +27,11 @@ import java.util.List;
 
 @JsonPropertyOrder({"cve", "epss", "percentile"})
 public class KevCatalog implements Serializable {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 3682701556631237639L;
     @JsonProperty("vulnerabilities")
     List<KevItem> vulnerabilities;
     @JsonProperty("title")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevDataFeed.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevDataFeed.java
@@ -41,7 +41,7 @@ public class KevDataFeed implements DataFeed<KevCatalog> {
      * Jackson object mapper.
      */
     private final ObjectMapper objectMapper;
-    private String downloadUrl;
+    private final String downloadUrl;
 
     public KevDataFeed() {
         this(DEFAULT_LOCATION);
@@ -58,14 +58,13 @@ public class KevDataFeed implements DataFeed<KevCatalog> {
         HttpGet request = new HttpGet(downloadUrl);
         SystemDefaultRoutePlanner planner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
         String json;
-        try (CloseableHttpClient client = HttpClientBuilder.create().setRoutePlanner(planner).build();) {
+        try (CloseableHttpClient client = HttpClientBuilder.create().setRoutePlanner(planner).build()) {
             json = client.execute(request, new BasicHttpClientResponseHandler());
         } catch (IOException e) {
             throw new KevException("Unable to download the Known Exploitable Vulnerability Catalog", e);
         }
         try {
-            KevCatalog response = objectMapper.readValue(json, KevCatalog.class);
-            return response;
+            return objectMapper.readValue(json, KevCatalog.class);
         } catch (JsonProcessingException e) {
             throw new KevException("Failed to parse JSON starting with: \"" + json.substring(0, 100) + "\"", e);
         }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevException.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevException.java
@@ -22,6 +22,12 @@ package io.github.jeremylong.openvulnerability.client.kev;
  * @author Jeremy Long
  */
 public class KevException extends RuntimeException {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 154565603317514766L;
+
     /**
      * Generate a new exception.
      *

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevItem.java
@@ -30,6 +30,11 @@ import java.util.Date;
 @JsonPropertyOrder({"cveID", "vendorProject", "product", "vulnerabilityName", "dateAdded", "shortDescription",
         "requiredAction", "dueDate", "notes"})
 public class KevItem implements Serializable {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -7179717694761725798L;
     @JsonProperty("cveID")
     private String cveID;
     @JsonProperty("vendorProject")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevItem.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.Date;
 
 /**
@@ -28,7 +29,7 @@ import java.util.Date;
  */
 @JsonPropertyOrder({"cveID", "vendorProject", "product", "vulnerabilityName", "dateAdded", "shortDescription",
         "requiredAction", "dueDate", "notes"})
-public class KevItem {
+public class KevItem implements Serializable {
     @JsonProperty("cveID")
     private String cveID;
     @JsonProperty("vendorProject")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Config.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Config.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +31,7 @@ import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"operator", "negate", "nodes"})
-public class Config {
+public class Config implements Serializable {
 
     @JsonProperty("operator")
     private Operator operator;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Config.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Config.java
@@ -33,6 +33,10 @@ import java.util.Objects;
 @JsonPropertyOrder({"operator", "negate", "nodes"})
 public class Config implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -6652299014788641511L;
     @JsonProperty("operator")
     private Operator operator;
     @JsonProperty("negate")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CpeMatch.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CpeMatch.java
@@ -32,6 +32,10 @@ import java.util.Objects;
 public class CpeMatch implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -7954886227420487016L;
+    /**
      * (Required)
      */
     @JsonProperty("vulnerable")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CpeMatch.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CpeMatch.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -28,7 +29,7 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"vulnerable", "criteria", "versionStartExcluding", "versionStartIncluding", "versionEndExcluding",
         "versionEndIncluding", "matchCriteriaId"})
-public class CpeMatch {
+public class CpeMatch implements Serializable {
 
     /**
      * (Required)

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveApiJson20.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveApiJson20.java
@@ -35,6 +35,11 @@ import java.util.Objects;
 @JsonPropertyOrder({"resultsPerPage", "startIndex", "totalResults", "format", "version", "timestamp",
         "vulnerabilities"})
 public class CveApiJson20 implements Serializable {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -7123674591462255117L;
     /**
      * (Required)
      */

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveApiJson20.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveApiJson20.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -33,7 +34,7 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"resultsPerPage", "startIndex", "totalResults", "format", "version", "timestamp",
         "vulnerabilities"})
-public class CveApiJson20 {
+public class CveApiJson20 implements Serializable {
     /**
      * (Required)
      */

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
@@ -36,6 +36,10 @@ import java.util.Objects;
         "references"})
 public class CveItem implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -3429894394769351686L;
     @JsonProperty("id")
     private String id;
     @JsonProperty("sourceIdentifier")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -33,7 +34,7 @@ import java.util.Objects;
         "evaluatorSolution", "evaluatorImpact", "cisaExploitAdd", "cisaActionDue", "cisaRequiredAction",
         "cisaVulnerabilityName", "descriptions", "vendorComments", "metrics", "weaknesses", "configurations",
         "references"})
-public class CveItem {
+public class CveItem implements Serializable {
 
     @JsonProperty("id")
     private String id;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -30,7 +31,7 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"source", "type", "cvssData", "baseSeverity", "exploitabilityScore", "impactScore", "acInsufInfo",
         "obtainAllPrivilege", "obtainUserPrivilege", "obtainOtherPrivilege", "userInteractionRequired"})
-public class CvssV2 {
+public class CvssV2 implements Serializable {
 
     public CvssV2() {
     }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2.java
@@ -33,6 +33,11 @@ import java.util.Objects;
         "obtainAllPrivilege", "obtainUserPrivilege", "obtainOtherPrivilege", "userInteractionRequired"})
 public class CvssV2 implements Serializable {
 
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 7595837336051753457L;
+
     public CvssV2() {
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2Data.java
@@ -37,6 +37,12 @@ import java.util.Objects;
         "remediationLevel", "reportConfidence", "temporalScore", "collateralDamagePotential", "targetDistribution",
         "confidentialityRequirement", "integrityRequirement", "availabilityRequirement", "environmentalScore"})
 public class CvssV2Data implements Serializable {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -3488320581980953116L;
+
     public CvssV2Data() {
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2Data.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -35,7 +36,7 @@ import java.util.Objects;
         "confidentialityImpact", "integrityImpact", "availabilityImpact", "baseScore", "exploitability",
         "remediationLevel", "reportConfidence", "temporalScore", "collateralDamagePotential", "targetDistribution",
         "confidentialityRequirement", "integrityRequirement", "availabilityRequirement", "environmentalScore"})
-public class CvssV2Data {
+public class CvssV2Data implements Serializable {
     public CvssV2Data() {
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3.java
@@ -31,6 +31,12 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"source", "type", "cvssData", "exploitabilityScore", "impactScore"})
 public class CvssV3 implements Serializable {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 3239377501678853019L;
+
     public CvssV3() {
     }
 
@@ -152,55 +158,55 @@ public class CvssV3 implements Serializable {
         }
         if (cvssData.getRemediationLevel() != null
                 && cvssData.getRemediationLevel() != CvssV3Data.RemediationLevelType.NOT_DEFINED) {
-            sb.append("/RL:").append(cvssData.getRemediationLevel().value().substring(0, 1));
+            sb.append("/RL:").append(cvssData.getRemediationLevel().value().charAt(0));
         }
         if (cvssData.getReportConfidence() != null
                 && cvssData.getReportConfidence() != CvssV3Data.ConfidenceType.NOT_DEFINED) {
-            sb.append("/RC:").append(cvssData.getReportConfidence().value().substring(0, 1));
+            sb.append("/RC:").append(cvssData.getReportConfidence().value().charAt(0));
         }
         if (cvssData.getConfidentialityRequirement() != null
                 && cvssData.getConfidentialityRequirement() != CvssV3Data.CiaRequirementType.NOT_DEFINED) {
-            sb.append("/CR:").append(cvssData.getConfidentialityRequirement().value().substring(0, 1));
+            sb.append("/CR:").append(cvssData.getConfidentialityRequirement().value().charAt(0));
         }
         if (cvssData.getIntegrityRequirement() != null
                 && cvssData.getIntegrityRequirement() != CvssV3Data.CiaRequirementType.NOT_DEFINED) {
-            sb.append("/IR:").append(cvssData.getIntegrityRequirement().value().substring(0, 1));
+            sb.append("/IR:").append(cvssData.getIntegrityRequirement().value().charAt(0));
         }
         if (cvssData.getAvailabilityRequirement() != null
                 && cvssData.getAvailabilityRequirement() != CvssV3Data.CiaRequirementType.NOT_DEFINED) {
-            sb.append("/AR:").append(cvssData.getAvailabilityRequirement().value().substring(0, 1));
+            sb.append("/AR:").append(cvssData.getAvailabilityRequirement().value().charAt(0));
         }
         if (cvssData.getModifiedAttackVector() != null
                 && cvssData.getModifiedAttackVector() != CvssV3Data.ModifiedAttackVectorType.NOT_DEFINED) {
-            sb.append("/MAV:").append(cvssData.getModifiedAttackVector().value().substring(0, 1));
+            sb.append("/MAV:").append(cvssData.getModifiedAttackVector().value().charAt(0));
         }
         if (cvssData.getModifiedAttackComplexity() != null
                 && cvssData.getModifiedAttackComplexity() != CvssV3Data.ModifiedAttackComplexityType.NOT_DEFINED) {
-            sb.append("/MAC:").append(cvssData.getModifiedAttackComplexity().value().substring(0, 1));
+            sb.append("/MAC:").append(cvssData.getModifiedAttackComplexity().value().charAt(0));
         }
         if (cvssData.getModifiedPrivilegesRequired() != null
                 && cvssData.getModifiedPrivilegesRequired() != CvssV3Data.ModifiedPrivilegesRequiredType.NOT_DEFINED) {
-            sb.append("/MPR:").append(cvssData.getModifiedPrivilegesRequired().value().substring(0, 1));
+            sb.append("/MPR:").append(cvssData.getModifiedPrivilegesRequired().value().charAt(0));
         }
         if (cvssData.getModifiedUserInteraction() != null
                 && cvssData.getModifiedUserInteraction() != CvssV3Data.ModifiedUserInteractionType.NOT_DEFINED) {
-            sb.append("/MUI:").append(cvssData.getModifiedUserInteraction().value().substring(0, 1));
+            sb.append("/MUI:").append(cvssData.getModifiedUserInteraction().value().charAt(0));
         }
         if (cvssData.getModifiedScope() != null
                 && cvssData.getModifiedScope() != CvssV3Data.ModifiedScopeType.NOT_DEFINED) {
-            sb.append("/MS:").append(cvssData.getModifiedScope().value().substring(0, 1));
+            sb.append("/MS:").append(cvssData.getModifiedScope().value().charAt(0));
         }
         if (cvssData.getModifiedConfidentialityImpact() != null
                 && cvssData.getModifiedConfidentialityImpact() != CvssV3Data.ModifiedCiaType.NOT_DEFINED) {
-            sb.append("/MC:").append(cvssData.getModifiedConfidentialityImpact().value().substring(0, 1));
+            sb.append("/MC:").append(cvssData.getModifiedConfidentialityImpact().value().charAt(0));
         }
         if (cvssData.getModifiedIntegrityImpact() != null
                 && cvssData.getModifiedIntegrityImpact() != CvssV3Data.ModifiedCiaType.NOT_DEFINED) {
-            sb.append("/MI:").append(cvssData.getModifiedIntegrityImpact().value().substring(0, 1));
+            sb.append("/MI:").append(cvssData.getModifiedIntegrityImpact().value().charAt(0));
         }
         if (cvssData.getModifiedAvailabilityImpact() != null
                 && cvssData.getModifiedAvailabilityImpact() != CvssV3Data.ModifiedCiaType.NOT_DEFINED) {
-            sb.append("/MA:").append(cvssData.getModifiedAvailabilityImpact().value().substring(0, 1));
+            sb.append("/MA:").append(cvssData.getModifiedAvailabilityImpact().value().charAt(0));
         }
         return sb.toString();
     }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3.java
@@ -23,13 +23,14 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"source", "type", "cvssData", "exploitabilityScore", "impactScore"})
-public class CvssV3 {
+public class CvssV3 implements Serializable {
     public CvssV3() {
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3Data.java
@@ -40,6 +40,12 @@ import java.util.Objects;
         "modifiedScope", "modifiedConfidentialityImpact", "modifiedIntegrityImpact", "modifiedAvailabilityImpact",
         "environmentalScore", "environmentalSeverity"})
 public class CvssV3Data implements Serializable {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 8537782209754450697L;
+
     public CvssV3Data() {
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3Data.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -38,7 +39,7 @@ import java.util.Objects;
         "modifiedAttackVector", "modifiedAttackComplexity", "modifiedPrivilegesRequired", "modifiedUserInteraction",
         "modifiedScope", "modifiedConfidentialityImpact", "modifiedIntegrityImpact", "modifiedAvailabilityImpact",
         "environmentalScore", "environmentalSeverity"})
-public class CvssV3Data {
+public class CvssV3Data implements Serializable {
     public CvssV3Data() {
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/DefCveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/DefCveItem.java
@@ -20,11 +20,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"cve"})
-public class DefCveItem {
+public class DefCveItem implements Serializable {
 
     /**
      * (Required)

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/DefCveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/DefCveItem.java
@@ -28,6 +28,10 @@ import java.util.Objects;
 public class DefCveItem implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 8372992609837009849L;
+    /**
      * (Required)
      */
     @JsonProperty("cve")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/LangString.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/LangString.java
@@ -28,6 +28,10 @@ import java.util.Objects;
 public class LangString implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 691162195898166591L;
+    /**
      * (Required)
      */
     @JsonProperty("lang")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/LangString.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/LangString.java
@@ -20,11 +20,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"lang", "value"})
-public class LangString {
+public class LangString implements Serializable {
 
     /**
      * (Required)

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Metrics.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Metrics.java
@@ -34,6 +34,10 @@ import java.util.Objects;
 public class Metrics implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 2506888424662802743L;
+    /**
      * CVSS V3.1 score.
      */
     @JsonProperty("cvssMetricV31")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Metrics.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Metrics.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,7 +31,7 @@ import java.util.Objects;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"cvssMetricV31", "cvssMetricV30", "cvssMetricV2"})
-public class Metrics {
+public class Metrics implements Serializable {
 
     /**
      * CVSS V3.1 score.

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Node.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Node.java
@@ -37,6 +37,10 @@ import java.util.Objects;
 public class Node implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = 3573822908057141798L;
+    /**
      * (Required)
      */
     @JsonProperty("operator")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Node.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Node.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,7 @@ import java.util.Objects;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"operator", "negate", "cpeMatch"})
-public class Node {
+public class Node implements Serializable {
 
     /**
      * (Required)

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdApiException.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdApiException.java
@@ -22,6 +22,12 @@ package io.github.jeremylong.openvulnerability.client.nvd;
  * @author Jeremy Long
  */
 public class NvdApiException extends RuntimeException {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -6730557637335641024L;
+
     /**
      * Generate a new exception.
      *

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdApiRetryExceededException.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdApiRetryExceededException.java
@@ -22,6 +22,12 @@ package io.github.jeremylong.openvulnerability.client.nvd;
  * @author Jeremy Long
  */
 public class NvdApiRetryExceededException extends RuntimeException {
+
+    /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -8352647741306381271L;
+
     /**
      * Generate a new exception.
      *

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -83,22 +83,18 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
     private final ObjectMapper objectMapper;
 
     /**
-     * The rate meter to limit traffic to the NVD API.
-     */
-    private RateMeter meter;
-    /**
      * The rate limited HTTP client for calling the NVD APIs.
      */
     private List<RateLimitedClient> clients;
     /**
      * The list of future responses.
      */
-    private List<Future<RateLimitedCall>> futures = new ArrayList<>();
+    private final List<Future<RateLimitedCall>> futures = new ArrayList<>();
     /**
      * The map of indexes to retrieve from the NVD and their retry count. This is used to retry when failures have
      * occurred on a single index.
      */
-    private Map<Integer, Integer> indexesToRetrieve = new HashMap<>();
+    private final Map<Integer, Integer> indexesToRetrieve = new HashMap<>();
     /**
      * Flag indicating if the first call has been made.
      */
@@ -114,7 +110,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
     /**
      * The maximum number of pages to retrieve from the NVD API.
      */
-    private int maxPageCount;
+    private final int maxPageCount;
     /**
      * A list of filters to apply to the request.
      */
@@ -160,12 +156,14 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             threadCount = 1;
         }
         this.maxPageCount = maxPageCount;
-        // configure the rate limit slightly higher then the published limits:
+        // configure the rate limit slightly higher than the published limits:
         // https://nvd.nist.gov/developers/start-here (see Rate Limits)
+
+        RateMeter meter;
         if (apiKey == null) {
             if (threadCount > 1) {
                 LOG.warn(
-                        "No api key provided; as such the thread count has been reset to 1 instead of the requestsed {}",
+                        "No api key provided; as such the thread count has been reset to 1 instead of the requested {}",
                         threadCount);
                 threadCount = 1;
             }
@@ -274,7 +272,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             return true;
         }
         if (futures.isEmpty() && !indexesToRetrieve.isEmpty()) {
-            queueUnsuccesful();
+            queueUnsuccessful();
         }
         return !futures.isEmpty();
     }
@@ -292,8 +290,8 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
         if (firstCall) {
             futures.add(callApi(0, 0));
         }
-        String json = "";
-        RateLimitedCall call = null;
+        String json;
+        RateLimitedCall call;
         try {
             call = getCompletedFuture();
             SimpleHttpResponse response = call.getResponse();
@@ -311,9 +309,6 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                     this.indexesToRetrieve.remove(call.getStartIndex());
                 } catch (JsonProcessingException e) {
                     return next();
-                    // throw new NvdApiException("Failed to parse JSON starting with: \"" + json.substring(0, 100) +
-                    // "\"",
-                    // e);
                 }
                 this.totalAvailable = current.getTotalResults();
                 lastUpdated = findLastUpdated(lastUpdated, current.getVulnerabilities());
@@ -322,7 +317,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                     queueCalls();
                 }
                 if (futures.isEmpty() && !indexesToRetrieve.isEmpty()) {
-                    queueUnsuccesful();
+                    queueUnsuccessful();
                 }
                 return current.getVulnerabilities();
             } else {
@@ -386,15 +381,16 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
         return null;
     }
 
-    private void queueUnsuccesful() {
+    private void queueUnsuccessful() {
         int clientIndex = 0;
         for (Map.Entry<Integer, Integer> i : indexesToRetrieve.entrySet()) {
             if (i.getValue() > 5) {
                 throw new NvdApiRetryExceededException("NVD Update Failed: attempted to retrieve starting index "
                         + i.getKey() + " from the NVD unsuccessfully five times.");
             }
-            i.setValue(i.getValue().intValue() + 1);
+            i.setValue(i.getValue() + 1);
             futures.add(callApi(clientIndex, i.getKey()));
+            clientIndex += 1;
             if (clientIndex >= clients.size()) {
                 clientIndex = 0;
             }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientBuilder.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientBuilder.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Used to build an NVD CVE API client. As the NvdCveClient client is autoclosable the builder should be used in a try
+ * Used to build an NVD CVE API client. As the NvdCveClient client is autocloseable the builder should be used in a try
  * with resources:
  *
  * <pre>
@@ -344,7 +344,7 @@ public final class NvdCveClientBuilder {
      */
     public enum Filter {
         /**
-         * Returns the vulnerabilties associated with a specific CPE.
+         * Returns the vulnerabilities associated with a specific CPE.
          *
          * <pre>
          * cpeName=cpe:2.3:a:apache:log4j:2.0:*:*:*:*:*:*:*
@@ -404,7 +404,7 @@ public final class NvdCveClientBuilder {
          */
         KEYWORD_EXACT_MATCH,
         /**
-         * Returns vulnerabilities where all of the keywords are in the description.
+         * Returns vulnerabilities where all the keywords are in the description.
          *
          * <pre>
          * keywordSearch = words

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedCall.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedCall.java
@@ -20,9 +20,9 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RateLimitedCall {
-    private SimpleHttpResponse response;
-    private int clientIndex;
-    private int startIndex;
+    private final SimpleHttpResponse response;
+    private final int clientIndex;
+    private final int startIndex;
 
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP",
             "EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -44,9 +44,9 @@ import java.util.concurrent.Future;
  * The two mechanisms may appear redundant - but each have its purpose in making the calls as fast as can be done while
  * being kind to the endpoint. If one is calling an endpoint, such as the NVD vulnerability API which is limited to 5
  * calls in 30 seconds without an API Key, to retrieve 4 page of data as quickly as possible you could set a smaller
- * delay and still keep the Rate Meter to limit to 5 calls per 30 seconds. However, if you are retrieving a large
- * number of pages you would want the delay to be slightly under the time period divided by the allowed number of calls
- * (e.g., if we allowed 5 calls over 30 seconds we would use 30/5=6 seconds).
+ * delay and still keep the Rate Meter to limit to 5 calls per 30 seconds. However, if you are retrieving a large number
+ * of pages you would want the delay to be slightly under the time period divided by the allowed number of calls (e.g.,
+ * if we allowed 5 calls over 30 seconds we would use 30/5=6 seconds).
  */
 class RateLimitedClient implements AutoCloseable {
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -20,18 +20,11 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
-import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.function.Factory;
-import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
-import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLEngine;
 import java.net.ProxySelector;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
@@ -51,7 +44,7 @@ import java.util.concurrent.Future;
  * The two mechanisms may appear redundant - but each have its purpose in making the calls as fast as can be done while
  * being kind to the endpoint. If one is calling an endpoint, such as the NVD vulnerability API which is limited to 5
  * calls in 30 seconds without an API Key, to retrieve 4 page of data as quickly as possible you could set a smaller
- * delay and still keep the Rate Meter to limit to 5 calls per 30 secnods. However, if you are retrieiving a large
+ * delay and still keep the Rate Meter to limit to 5 calls per 30 seconds. However, if you are retrieving a large
  * number of pages you would want the delay to be slightly under the time period divided by the allowed number of calls
  * (e.g., if we allowed 5 calls over 30 seconds we would use 30/5=6 seconds).
  */
@@ -66,7 +59,7 @@ class RateLimitedClient implements AutoCloseable {
      */
     private final CloseableHttpAsyncClient client;
     /**
-     * Executor service for asynch implementation.
+     * Executor service for async implementation.
      */
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     /**
@@ -76,11 +69,11 @@ class RateLimitedClient implements AutoCloseable {
     /**
      * The minimum delay in milliseconds between API calls.
      */
-    private long delay = 0;
+    private long delay;
     /**
      * Rate limiting meter.
      */
-    private RateMeter meter;
+    private final RateMeter meter;
 
     /**
      * Construct a rate limited client without a delay or limiters.
@@ -156,9 +149,7 @@ class RateLimitedClient implements AutoCloseable {
      * @return the future response
      */
     Future<RateLimitedCall> execute(SimpleHttpRequest request, int clientIndex, int startIndex) {
-        return executor.submit(() -> {
-            return delayedExecute(request, clientIndex, startIndex);
-        });
+        return executor.submit(() -> delayedExecute(request, clientIndex, startIndex));
     }
 
     /**
@@ -201,7 +192,7 @@ class RateLimitedClient implements AutoCloseable {
     /**
      * Future response.
      */
-    class SimpleFutureResponse implements FutureCallback<SimpleHttpResponse> {
+    static class SimpleFutureResponse implements FutureCallback<SimpleHttpResponse> {
         /**
          * Reference to the logger.
          */
@@ -209,8 +200,6 @@ class RateLimitedClient implements AutoCloseable {
 
         @Override
         public void completed(SimpleHttpResponse result) {
-            // String response = result.getBodyText();
-            // log.debug("response::{}", response);
         }
 
         @Override

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Reference.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Reference.java
@@ -21,12 +21,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"url", "source", "tags"})
-public class Reference {
+public class Reference implements Serializable {
 
     /**
      * (Required)

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Reference.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Reference.java
@@ -30,6 +30,10 @@ import java.util.Objects;
 public class Reference implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -224192309845772254L;
+    /**
      * (Required)
      */
     @JsonProperty("url")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/VendorComment.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/VendorComment.java
@@ -30,6 +30,10 @@ import java.util.Objects;
 public class VendorComment implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -5866678952379674377L;
+    /**
      * (Required)
      */
     @JsonProperty("organization")
@@ -43,8 +47,8 @@ public class VendorComment implements Serializable {
      * (Required)
      */
     @JsonProperty("lastModified")
-    // the below format is a hack work around due to some poorly formated dates in the NVD data, the getter corrects the
-    // serizlized format
+    // the below format is a hack/workaround due to some poorly formatted dates in the NVD data, the getter corrects the
+    // serialized format
     @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS][SSSSSSSS][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]]", timezone = "UTC")
     private ZonedDateTime lastModified;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/VendorComment.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/VendorComment.java
@@ -21,12 +21,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"organization", "comment", "lastModified"})
-public class VendorComment {
+public class VendorComment implements Serializable {
 
     /**
      * (Required)

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Weakness.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Weakness.java
@@ -30,6 +30,10 @@ import java.util.Objects;
 public class Weakness implements Serializable {
 
     /**
+     * Serialization version UID.
+     */
+    private static final long serialVersionUID = -6330752220797574809L;
+    /**
      * (Required)
      */
     @JsonProperty("source")

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Weakness.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Weakness.java
@@ -21,12 +21,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"source", "type", "description"})
-public class Weakness {
+public class Weakness implements Serializable {
 
     /**
      * (Required)

--- a/vulnz/README.md
+++ b/vulnz/README.md
@@ -54,7 +54,7 @@ export JAVA_OPTS="-Xmx2g"
 Alternatively, run the CLI using the `-Xmx2g` argument:
 
 ```bash
-java -Xmx2g -jar ./vulnz-5.0.0.jar
+java -Xmx2g -jar ./vulnz-5.0.1.jar
 ```
 
 ### Creating the Cache
@@ -71,7 +71,7 @@ for file in *.json; do gzip -k "${file}"; done
 Alternatively, without using the above install command:
 
 ```bash
-./vulnz-5.0.0.jar cve --cache --directory ./cache
+./vulnz-5.0.1.jar cve --cache --directory ./cache
 cd cache
 for file in *.json; do gzip -k "${file}"; done 
 ```


### PR DESCRIPTION
While the POJOs are annotated for JSON serialization, they should also implement `Serializable`. Additionally, this PR contains several spelling, grammar, and code improvements suggested by Intellij.