### PR TITLE
"Improved error response handling in NvdCveClient"

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -20,9 +20,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.github.jeremylong.openvulnerability.client.PagedDataSource;
+import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.net.URIBuilder;
 import org.slf4j.Logger;
@@ -278,12 +281,15 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
     }
 
     /**
-     * <p>
-     * Retrieves the next entry. Note that even if `hasNext()` returns true it is possible that `next()` will return
-     * null. This will generally only occur on the very first call.
-     * </p>
+     * Continuously calls the NVD API until it receives a successful response, which it then processes and returns. If
+     * the NVD API returns a 503 status (Service Unavailable), it will try again after a delay, up to a maximum number
+     * of retries. If the thread is interrupted, or if it encounters an ExecutionException or JsonProcessingException,
+     * it logs the error and tries again.
      *
-     * @return the next collection of CVE entries
+     * @throws NvdApiException If the NVD service is persistently unavailable or if the data retrieval or JSON
+     *     processing fails after all retries.
+     * @return Collection of DefCveItem objects which contain details on the extracted vulnerabilities from the NVD
+     * API's JSON response.
      */
     @Override
     public Collection<DefCveItem> next() {
@@ -291,52 +297,113 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             futures.add(callApi(0, 0));
         }
         String json;
-        RateLimitedCall call;
-        try {
-            call = getCompletedFuture();
-            SimpleHttpResponse response = call.getResponse();
-            if (response.getCode() == 200) {
-                LOG.debug("Content-Type Received: {}", response.getContentType());
-                json = response.getBodyText();
-                // resolve issue #20
-                if (json == null && response.getBody().isBytes()) {
-                    json = new String(response.getBodyBytes(), StandardCharsets.UTF_8);
+        int retryCount = 0; // counter for API call retries
+        final int maxRetries = 10; // defines the maximum attempts for retries
+        final long defaultRetryAfter = 10; // defines the default time to wait before retrying the API call
+
+        while (true) {
+            RateLimitedCall call = null; // Declare 'call' outside the try block
+            try {
+                call = getCompletedFuture();
+                SimpleHttpResponse response = null;
+                // Check if the call is not null and get the response
+                if (call != null) {
+                    response = call.getResponse();
+                }
+                int statusCode = 0;
+                // Check if the response is not null and get the status code from it
+                if (response != null) {
+                    statusCode = response.getCode();
                 }
 
-                CveApiJson20 current;
-                try {
-                    current = objectMapper.readValue(json, CveApiJson20.class);
+                // If the status code is OK, process the response
+                if (statusCode == HttpStatus.SC_OK) {
+                    json = response.getBodyText();
+                    // In case the response body is in byte format, convert it to string
+                    if (json == null && response.getBody().isBytes()) {
+                        json = new String(response.getBodyBytes(), StandardCharsets.UTF_8);
+                    }
+                    // Parse the response JSON into CveApiJson20 object
+                    CveApiJson20 current = objectMapper.readValue(json, CveApiJson20.class);
                     this.indexesToRetrieve.remove(call.getStartIndex());
-                } catch (JsonProcessingException e) {
-                    return next();
+                    this.totalAvailable = current.getTotalResults();
+                    lastUpdated = findLastUpdated(lastUpdated, current.getVulnerabilities());
+                    if (firstCall) {
+                        firstCall = false;
+                        queueCalls();
+                    }
+                    if (futures.isEmpty() && !indexesToRetrieve.isEmpty()) {
+                        queueUnsuccessful();
+                    }
+                    return current.getVulnerabilities();
                 }
-                this.totalAvailable = current.getTotalResults();
-                lastUpdated = findLastUpdated(lastUpdated, current.getVulnerabilities());
-                if (firstCall) {
-                    firstCall = false;
-                    queueCalls();
+                // If the Service is Unavailable, it will retry calling the API after specified seconds
+                else if (statusCode == HttpStatus.SC_SERVICE_UNAVAILABLE) {
+                    if (retryCount >= maxRetries) {
+                        LOG.error("NVD service unavailable after {} retries", maxRetries);
+                        throw new NvdApiException("NVD service unavailable after " + maxRetries + " retries");
+                    }
+                    retryCount++;
+                    long retryAfter = extractRetryAfter(response, defaultRetryAfter);
+                    LOG.info("503 Service Unavailable received on attempt {}. Will retry after {} seconds", retryCount,
+                            retryAfter);
+                    TimeUnit.SECONDS.sleep(retryAfter);
+                } else {
+                    lastStatusCode = statusCode;
+                    LOG.error("Unexpected Status Code: {}. Response: {}", lastStatusCode,
+                            response != null ? response.getBodyText() : "No Response");
+                    throw new NvdApiException("NVD Returned Status Code: " + lastStatusCode);
                 }
-                if (futures.isEmpty() && !indexesToRetrieve.isEmpty()) {
-                    queueUnsuccessful();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOG.error("Thread interruption during NVD data retrieval. Attempt: {}", retryCount, e);
+                throw new NvdApiException("Thread was interrupted", e);
+            } catch (ExecutionException e) {
+                if (retryCount >= maxRetries) {
+                    LOG.error("Execution exception after max retries {}", maxRetries, e);
+                    throw new NvdApiException("Failed to retrieve NVD data after " + maxRetries + " retries", e);
                 }
-                return current.getVulnerabilities();
-            } else {
-                lastStatusCode = response.getCode();
-                LOG.debug("Status Code: {}", lastStatusCode);
-                LOG.debug("Response: {}", response.getBodyText());
-                throw new NvdApiException("NVD Returned Status Code: " + lastStatusCode);
+                LOG.debug("Execution exception during NVD data retrieval. Attempt: {}", retryCount, e);
+                retryCount++;
+            } catch (JsonProcessingException e) {
+                if (retryCount >= maxRetries) {
+                    LOG.error("JSON processing failed after max retries {}", maxRetries, e);
+                    throw new NvdApiException("JSON processing failed after " + maxRetries + " retries", e);
+                }
+                LOG.debug("JSON processing exception during NVD data retrieval. Attempt: {}", retryCount, e);
+                retryCount++;
             }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new NvdApiException(e);
-        } catch (ExecutionException e) {
-            // in rare cases we get an error from the NVD - log the error and only fail if we retry too many times
-            LOG.debug("Error retrieving the NVD data", e);
-            if (hasNext()) {
-                return next();
+            finally {
+                if (call != null && call.getResponse() != null) {
+                    // Ensure that the RateLimitedCall object is always freed, even if an exception is thrown
+                    call.getResponse().clear();
+                }
             }
-            return null;
         }
+    }
+
+    /**
+     * This method is used to extract the "Retry-After" value from the headers of a HTTP response. If the "Retry-After"
+     * header is not present or contains an invalid value, a default value is returned.
+     *
+     * @param response The SimpleHttpResponse from which the "Retry-After" value is to be extracted.
+     * @param defaultRetryAfter The default value to return if the "Retry-After" header is not present or contains an
+     *     invalid value.
+     * @return The value of the "Retry-After" header if present and valid, else the default value passed.
+     */
+    private long extractRetryAfter(SimpleHttpResponse response, long defaultRetryAfter) {
+        // Iterate through each header in the response
+        for (Header header : response.getHeaders()) {
+            // If the "Retry-After" header is found, parse its value
+            if ("Retry-After".equalsIgnoreCase(header.getName())) {
+                try {
+                    return Long.parseLong(header.getValue());
+                } catch (NumberFormatException e) {
+                    LOG.debug("Invalid Retry-After header value", e);
+                }
+            }
+        }
+        return defaultRetryAfter;
     }
 
     /**


### PR DESCRIPTION
This commit enhances how NvdCveClient handles unsuccessful API responses. If the service is unavailable (status 503), the client will now retry after specific seconds, up to a maximum number of retries. If a thread is interrupted or encounters an ExecutionException or JsonProcessingException, the error is logged and the API call is retried. If all retries fail, an NvdApiException is thrown. Added methods to extract the "Retry-After" value from response headers. This improves the client's robustness against transient issues and ensures we don't prematurely fail on temporary setbacks.