### PR TITLE
fix: retry 502 and 504

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdApiRetryStrategy.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdApiRetryStrategy.java
@@ -55,7 +55,7 @@ public class NvdApiRetryStrategy extends DefaultHttpRequestRetryStrategy {
 
     public NvdApiRetryStrategy(int maxRetries, long delay) {
         super(maxRetries, TimeValue.of(delay, TimeUnit.MILLISECONDS), new ArrayList<Class<? extends IOException>>(),
-                Arrays.asList(429, 503));
+                Arrays.asList(429, 502, 503, 504));
         this.maxRetries = maxRetries;
         this.delay = delay;
     }


### PR DESCRIPTION
Failed requests with 502 and 504 should also be retried as they usually also indicate short term failures.