### PR TITLE
Update mirror.sh to fix DELAY Override

### DIFF
--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -7,7 +7,7 @@ if [ -z $NVD_API_KEY ]; then
   DELAY_ARG="--delay=10000"
 fi
 
-if [ -z $DELAY ]; then
+if [ -n "${DELAY}" ]; then
   DELAY_ARG="--delay=$DELAY"
 fi
 


### PR DESCRIPTION
This primarily fix situation where DELAY override is incorrect.

Previous behaviors:
* If DELAY is unset, will set DELAY_ARG to "--delay=" (empty string after equal sign) 
* If DELAY is set, DELAY_ARG will be set to "--delay=10000" if NVD_API_KEY unspecified. DELAY value will never be used.

Changed Behavior
* If DELAY is unset, 
    * if NVD_API_KEY unspecified, DELAY_ARG will be set to "--delay=10000"
    * if NVD_API_KEY specified, DELAY_ARG will be empty string (I assume will default to value in CLI)
* If DELAY is set , for example to "1234", DELAY_ARG will be set to "--delay=1234"