### PR TITLE
Fix failure starting docker caused by EAccess error visible in docker…

### DIFF
--- a/vulnz/src/docker/conf/supervisord.conf
+++ b/vulnz/src/docker/conf/supervisord.conf
@@ -20,4 +20,3 @@ autorestart=false
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
-user=mirror


### PR DESCRIPTION
Remove user mirror from being required to execute mirror.sh in Supervisor

See detail in https://github.com/jeremylong/Open-Vulnerability-Project/issues/126