### PR TITLE
Fix typo in identifier: 'vunlz' to 'vulnz'

### DIFF
--- a/vulnz/README.md
+++ b/vulnz/README.md
@@ -139,8 +139,8 @@ Assuming the current version is `5.1.1`
 
 ```bash
 export TARGET_VERSION=5.1.1
-./gradlew vunlz:build -Pversion=$TARGET_VERSION
-docker build vunlz/ -t ghcr.io/jeremylong/vulnz:$TARGET_VERSION --build-arg BUILD_VERSION=$TARGET_VERSION
+./gradlew vulnz:build -Pversion=$TARGET_VERSION
+docker build vulnz/ -t ghcr.io/jeremylong/vulnz:$TARGET_VERSION --build-arg BUILD_VERSION=$TARGET_VERSION
 ```
 
 ### Release


### PR DESCRIPTION
Fix typo in identifier: 'vunlz' to 'vulnz'