### PR TITLE
Add permissions to mirror user to fix Docker start failure (EAccess)

### DIFF
--- a/vulnz/Dockerfile
+++ b/vulnz/Dockerfile
@@ -38,6 +38,13 @@ COPY ["/src/docker/crontab/mirror", "/etc/crontabs/mirror"]
 COPY ["/src/docker/conf/mirror.conf", "/usr/local/apache2/conf"]
 COPY ["/build/libs/vulnz-$BUILD_VERSION.jar", "/usr/local/bin/vulnz"]
 
+RUN chmod +x /mirror.sh && \
+    chown mirror:mirror /etc/supervisor/conf.d/supervisord.conf && \
+    chown mirror:mirror /mirror.sh && \
+    chown mirror:mirror /etc/crontabs/mirror && \
+    chown -R mirror:mirror /usr/local/apache2 && \
+    chown mirror:mirror /usr/local/bin/vulnz
+
 VOLUME /usr/local/apache2/htdocs
 EXPOSE 80/tcp
 


### PR DESCRIPTION
This commit grants the necessary permissions to the 'mirror' user to resolve a Docker start failure issue, specifically an access error (EAccess). It was found that this error was due to insufficient permissions for the 'mirror' user. By providing the appropriate permissions, Docker can now start without issues, thereby eliminating the error that was hindering its proper operation.