### PR TITLE
Rework and polish docker image

### DIFF
--- a/vulnz/Dockerfile
+++ b/vulnz/Dockerfile
@@ -26,26 +26,27 @@ ENV BUILD_VERSION=$BUILD_VERSION
 ENV JAVA_OPT=-Xmx2g
 
 RUN apk update                                                && \
-    apk add --no-cache bash openjdk11 dcron nss supervisor    && \
+    apk add --no-cache bash openjdk17 dcron nss supervisor    && \
     addgroup -S "$user"                                       && \
     adduser -S "$user" -G "$user"                             && \
+    addgroup "$user" www-data                                 && \
+    addgroup www-data "$user"                                 && \
     chown -R "$user":"$user" /usr/local/apache2/htdocs        && \
     rm -v /usr/local/apache2/htdocs/index.html
 
-COPY ["/src/docker/conf/supervisord.conf", "/etc/supervisor/conf.d/supervisord.conf"]
+COPY ["/src/docker/conf/supervisord.conf", "/etc/supervisord.conf"]
 COPY ["/src/docker/scripts/mirror.sh", "/mirror.sh"]
 COPY ["/src/docker/crontab/mirror", "/etc/crontabs/mirror"]
 COPY ["/src/docker/conf/mirror.conf", "/usr/local/apache2/conf"]
 COPY ["/build/libs/vulnz-$BUILD_VERSION.jar", "/usr/local/bin/vulnz"]
 
 RUN chmod +x /mirror.sh && \
-    chown mirror:mirror /etc/supervisor/conf.d/supervisord.conf && \
     chown mirror:mirror /mirror.sh && \
     chown mirror:mirror /etc/crontabs/mirror && \
-    chown -R mirror:mirror /usr/local/apache2 && \
     chown mirror:mirror /usr/local/bin/vulnz
 
 VOLUME /usr/local/apache2/htdocs
+WORKDIR /usr/local/apache2/htdocs
 EXPOSE 80/tcp
 
-CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/conf.d/supervisord.conf", "-l", "/var/log/supervisord.log", "-j", "/var/run/supervisord.pid"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/vulnz/Dockerfile
+++ b/vulnz/Dockerfile
@@ -44,7 +44,7 @@ COPY ["/build/libs/vulnz-$BUILD_VERSION.jar", "/usr/local/bin/vulnz"]
 RUN chmod +x /mirror.sh && \
     chown mirror:mirror /mirror.sh && \
     chown mirror:mirror /etc/crontabs/mirror && \
-    chown mirror:mirror /usr/local/bin/vulnz \
+    chown mirror:mirror /usr/local/bin/vulnz 
 
 # ensures our cron task is logged into stdout of docker
 RUN ln -sf /proc/1/fd/1 /var/log/cron_mirror.log

--- a/vulnz/Dockerfile
+++ b/vulnz/Dockerfile
@@ -44,7 +44,10 @@ COPY ["/build/libs/vulnz-$BUILD_VERSION.jar", "/usr/local/bin/vulnz"]
 RUN chmod +x /mirror.sh && \
     chown mirror:mirror /mirror.sh && \
     chown mirror:mirror /etc/crontabs/mirror && \
-    chown mirror:mirror /usr/local/bin/vulnz
+    chown mirror:mirror /usr/local/bin/vulnz \
+
+# ensures our cron task is logged into stdout of docker
+RUN ln -sf /proc/1/fd/1 /var/log/cron_mirror.log
 
 VOLUME /usr/local/apache2/htdocs
 WORKDIR /usr/local/apache2/htdocs

--- a/vulnz/Dockerfile
+++ b/vulnz/Dockerfile
@@ -32,6 +32,7 @@ RUN apk update                                                && \
     addgroup "$user" www-data                                 && \
     addgroup www-data "$user"                                 && \
     chown -R "$user":"$user" /usr/local/apache2/htdocs        && \
+    mkdir -p /var/log/supervisor && \
     rm -v /usr/local/apache2/htdocs/index.html
 
 COPY ["/src/docker/conf/supervisord.conf", "/etc/supervisord.conf"]

--- a/vulnz/src/docker/conf/supervisord.conf
+++ b/vulnz/src/docker/conf/supervisord.conf
@@ -7,7 +7,7 @@ username = dummy
 password = dummy
 
 [supervisord]
-logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=5MB
 logfile_backups=3
 nodaemon=true

--- a/vulnz/src/docker/conf/supervisord.conf
+++ b/vulnz/src/docker/conf/supervisord.conf
@@ -1,20 +1,58 @@
-[supervisord]
-nodaemon=true
-user=root
+; supervisor config file
 
-[program:crond]
-command=crond -s /var/spool/cron/crontabs -f
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
+[unix_http_server]
+file=/dev/shm/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+username = dummy
+password = dummy
+
+[supervisord]
+logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile_maxbytes=5MB
+logfile_backups=3
+nodaemon=true
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+loglevel = WARN
+# Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
+user = root
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///dev/shm/supervisor.sock ; use a unix:// URL  for a unix socket
+username = dummy
+password = dummy
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf
 
 [program:httpd]
+priority=1
 command=/usr/local/bin/httpd-foreground
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
-[program:initialize_htdocs]
+[program:crond]
+priority=3
+command=crond -s /var/spool/cron/crontabs -f
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
+[program:init_nvd_cache]
+priority=2
 command=/mirror.sh
 autorestart=false
 stdout_logfile=/dev/fd/1

--- a/vulnz/src/docker/crontab/mirror
+++ b/vulnz/src/docker/crontab/mirror
@@ -1,1 +1,1 @@
-0 0 * * * mirror /mirror.sh
+0 0 * * * /mirror.sh >> /var/log/cron_mirror.log 2>&1

--- a/vulnz/src/docker/crontab/mirror
+++ b/vulnz/src/docker/crontab/mirror
@@ -1,1 +1,1 @@
-0 0 * * * /mirror.sh
+0 0 * * * mirror /mirror.sh

--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -5,10 +5,17 @@ echo "Updating..."
 DELAY_ARG=""
 if [ -z $NVD_API_KEY ]; then
   DELAY_ARG="--delay=10000"
+else
+  echo "Using NVD API KEY: $NVD_API_KEY"
 fi
 
 if [ -n "${DELAY}" ]; then
+  echo "Overriding delay with ${DELAY}ms"
   DELAY_ARG="--delay=$DELAY"
 fi
 
-java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG --cache --directory /usr/local/apache2/htdocs
+if [ -n "${DEBUG}" ]; then
+  DEBUG_ARG="--delay"
+fi
+
+java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG --cache --directory /usr/local/apache2/htdocs

--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -29,5 +29,4 @@ if [ -n "${DEBUG}" ]; then
   DEBUG_ARG="--debug"
 fi
 
-MAX_RECORDS_PER_PAGE
 java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs

--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -14,8 +14,20 @@ if [ -n "${DELAY}" ]; then
   DELAY_ARG="--delay=$DELAY"
 fi
 
-if [ -n "${DEBUG}" ]; then
-  DEBUG_ARG="--delay"
+if [ -n "${MAX_RETRY}" ]; then
+  echo "Using max retry attempts: $MAX_RECORDS_PER_PAGE"
+  MAX_RETRY_ARG="--maxRetry=$MAX_RETRY"
 fi
 
-java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG --cache --directory /usr/local/apache2/htdocs
+if [ -n "${MAX_RECORDS_PER_PAGE}" ]; then
+  echo "Using max records per page: $MAX_RECORDS_PER_PAGE"
+  MAX_RECORDS_PER_PAGE_ARG="--recordsPerPage=$MAX_RECORDS_PER_PAGE"
+fi
+
+if [ -n "${DEBUG}" ]; then
+  echo "Enabling debug mode"
+  DEBUG_ARG="--debug"
+fi
+
+MAX_RECORDS_PER_PAGE
+java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs


### PR DESCRIPTION
Rework different aspects of the docker image

1. Add flags as ENV to enable debug, set maxRetries, or max records per page ( more https://github.com/EugenMayer/helm-charts/blob/main/charts/vulnz-nvd-mirror/values.yaml#L44 )
2. Use jdk17 (not 11;v
3. Fix cron setup and logging
4. Fix supervisor setup using wrong configuration (supervisorctl was unusable without flags)
5. Polish supervisor configuration
6. ensure proper group memberships 
7. Better startup logging

Changes should be squashed on merge