### PR TITLE
build(deps): bump versions

### DIFF
--- a/vulnz/build.gradle
+++ b/vulnz/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'vuln.tools.java-application-conventions'
-    id 'org.springframework.boot' version '2.7.11'
+    id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
@@ -11,9 +11,11 @@ description = 'A java CLI to call the NVD API'
 ext['httpclient5.version'] = '5.2.1'
 ext['httpcore5.version'] = '5.2'
 ext['httpcore5-h2.version'] = '5.2'
+ext['snakeyaml.version'] = '2.2'
+//ext['logback.version'] = '1.3.14'
 dependencies {
     implementation project(':open-vulnerability-clients')
-    implementation 'info.picocli:picocli-spring-boot-starter:4.7.4'
+    implementation 'info.picocli:picocli-spring-boot-starter:4.7.5'
     implementation 'com.diogonunes:JColor:5.5.1'
     implementation 'commons-io:commons-io:2.15.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'


### PR DESCRIPTION
Fixes some of the CVEs in transitive dependencies. I do not believe any of the CVEs affect the `vulnz` CLI; but we are upgrading anyway.