### PR TITLE
Ignore unkown properties on CveItem to support new 'cveTags' property

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
@@ -19,6 +19,7 @@ package io.github.jeremylong.openvulnerability.client.nvd;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"id", "sourceIdentifier", "published", "lastModified", "vulnStatus", "evaluatorComment",
         "evaluatorSolution", "evaluatorImpact", "cisaExploitAdd", "cisaActionDue", "cisaRequiredAction",
         "cisaVulnerabilityName", "descriptions", "vendorComments", "metrics", "weaknesses", "configurations",

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -338,6 +338,8 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                         current = objectMapper.readValue(json, CveApiJson20.class);
                         this.indexesToRetrieve.remove(call.getStartIndex());
                     } catch (JsonProcessingException e) {
+                        LOG.debug("Error processing NVD data", e);
+                        // really re-fetch the same data?
                         return next();
                     }
                     this.totalAvailable = current.getTotalResults();


### PR DESCRIPTION
This is a fast fix for the [vulnz is failing cve caching from NVD due to an introduced 'cveTags' property](https://github.com/jeremylong/Open-Vulnerability-Project/issues/150) issue.

It simply ignores unkown properties on the CveItem.java and logs an error if the json parsing fails.