### PR TITLE
fix: Adding a call to shutdown()

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -88,8 +88,8 @@ class RateLimitedClient implements AutoCloseable {
      * configure 5 requests are allowed over a 30-second rolling window and we will delay at least 4 seconds between
      * calls to help more evenly distribute the calls across the request window.
      *
-     * @param minimumDelay the number of milliseconds to wait between API calls
-     * @param requestsCount the number of requests allowed during the rolling request window timespan
+     * @param minimumDelay              the number of milliseconds to wait between API calls
+     * @param requestsCount             the number of requests allowed during the rolling request window timespan
      * @param requestWindowMilliseconds the rolling request window size in milliseconds
      */
     RateLimitedClient(long minimumDelay, int requestsCount, long requestWindowMilliseconds) {
@@ -105,7 +105,7 @@ class RateLimitedClient implements AutoCloseable {
      * calls to help more evenly distribute the calls across the request window.
      *
      * @param minimumDelay the number of milliseconds to wait between API calls
-     * @param meter the rate meter to limit the request rate
+     * @param meter        the rate meter to limit the request rate
      */
     RateLimitedClient(long minimumDelay, RateMeter meter) {
         this(10, minimumDelay, meter, null);
@@ -116,9 +116,9 @@ class RateLimitedClient implements AutoCloseable {
      * configure 5 requests are allowed over a 30-second rolling window and we will delay at least 4 seconds between
      * calls to help more evenly distribute the calls across the request window.
      *
-     * @param maxRetries the maximum number of retry attemps
-     * @param minimumDelay the number of milliseconds to wait between API calls
-     * @param meter the rate meter to limit the request rate
+     * @param maxRetries         the maximum number of retry attemps
+     * @param minimumDelay       the number of milliseconds to wait between API calls
+     * @param meter              the rate meter to limit the request rate
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used
      */
     RateLimitedClient(int maxRetries, long minimumDelay, RateMeter meter, HttpAsyncClientSupplier httpClientSupplier) {
@@ -141,6 +141,7 @@ class RateLimitedClient implements AutoCloseable {
         if (client != null) {
             client.close();
         }
+        executor.shutdown();
     }
 
     /**
@@ -177,7 +178,7 @@ class RateLimitedClient implements AutoCloseable {
      *
      * @param request the request
      * @return the future response
-     * @throws ExecutionException thrown if there is an exception
+     * @throws ExecutionException   thrown if there is an exception
      * @throws InterruptedException thrown if interrupted
      */
     private RateLimitedCall delayedExecute(SimpleHttpRequest request, int clientIndex, int startIndex)


### PR DESCRIPTION
Adding a call to shutdown() to avoid the consequences of Executor error