### PR TITLE
fix: workaround lack of CVSSv4 support with consistently lenient JSON parsing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 6.0.1
+version = 6.0.2

--- a/open-vulnerability-clients/README.md
+++ b/open-vulnerability-clients/README.md
@@ -39,14 +39,14 @@ See API usage examples in the [open-vulnerability-store](https://github.com/jere
 <dependency>
    <groupId>io.github.jeremylong</groupId>
    <artifactId>open-vulnerability-clients</artifactId>
-   <version>6.0.1</version>
+   <version>6.0.2</version>
 </dependency>
 ```
 
 ### gradle
 
 ```groovy
-implementation 'io.github.jeremylong:open-vulnerability-clients:6.0.1'
+implementation 'io.github.jeremylong:open-vulnerability-clients:6.0.2'
 ```
 
 ### api usage

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/epss/EpssItem.java
@@ -16,6 +16,7 @@
  */
 package io.github.jeremylong.openvulnerability.client.epss;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
@@ -26,7 +27,7 @@ import java.io.Serializable;
  *
  * @see <a href="https://www.first.org/epss/">https://www.first.org/epss/</a>
  */
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"cve", "epss", "percentile"})
 public class EpssItem implements Serializable {
     /**

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevCatalog.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevCatalog.java
@@ -17,6 +17,7 @@
 package io.github.jeremylong.openvulnerability.client.kev;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -25,6 +26,7 @@ import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"cve", "epss", "percentile"})
 public class KevCatalog implements Serializable {
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/kev/KevItem.java
@@ -17,6 +17,7 @@
 package io.github.jeremylong.openvulnerability.client.kev;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -27,6 +28,7 @@ import java.util.Date;
 /**
  * Known Exploited Vulnerability.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"cveID", "vendorProject", "product", "vulnerabilityName", "dateAdded", "shortDescription",
         "requiredAction", "dueDate", "notes"})
 public class KevItem implements Serializable {

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Config.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Config.java
@@ -17,6 +17,7 @@
 package io.github.jeremylong.openvulnerability.client.nvd;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -30,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"operator", "negate", "nodes"})
 public class Config implements Serializable {
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CpeMatch.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CpeMatch.java
@@ -16,6 +16,7 @@
  */
 package io.github.jeremylong.openvulnerability.client.nvd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -27,6 +28,7 @@ import java.util.Objects;
  * CPE match string or range
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"vulnerable", "criteria", "versionStartExcluding", "versionStartIncluding", "versionEndExcluding",
         "versionEndIncluding", "matchCriteriaId"})
 public class CpeMatch implements Serializable {

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2Data.java
@@ -17,6 +17,7 @@
 package io.github.jeremylong.openvulnerability.client.nvd;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -32,6 +33,7 @@ import java.util.Objects;
  * JSON Schema for Common Vulnerability Scoring System version 2.0
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"version", "vectorString", "accessVector", "accessComplexity", "authentication",
         "confidentialityImpact", "integrityImpact", "availabilityImpact", "baseScore", "exploitability",
         "remediationLevel", "reportConfidence", "temporalScore", "collateralDamagePotential", "targetDistribution",

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3Data.java
@@ -17,6 +17,7 @@
 package io.github.jeremylong.openvulnerability.client.nvd;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -32,6 +33,7 @@ import java.util.Objects;
  * JSON Schema for Common Vulnerability Scoring System version 3.0
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"version", "vectorString", "attackVector", "attackComplexity", "privilegesRequired",
         "userInteraction", "scope", "confidentialityImpact", "integrityImpact", "availabilityImpact", "baseScore",
         "baseSeverity", "exploitCodeMaturity", "remediationLevel", "reportConfidence", "temporalScore",

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Metrics.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Metrics.java
@@ -16,6 +16,7 @@
  */
 package io.github.jeremylong.openvulnerability.client.nvd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -30,6 +31,7 @@ import java.util.Objects;
  * Metric scores for a vulnerability as found on NVD.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"cvssMetricV40", "cvssMetricV31", "cvssMetricV30", "cvssMetricV2"})
 public class Metrics implements Serializable {
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Node.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Node.java
@@ -17,6 +17,7 @@
 package io.github.jeremylong.openvulnerability.client.nvd;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -33,6 +34,7 @@ import java.util.Objects;
  * Defines a configuration node in an NVD applicability statement.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"operator", "negate", "cpeMatch"})
 public class Node implements Serializable {
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Reference.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/Reference.java
@@ -16,6 +16,7 @@
  */
 package io.github.jeremylong.openvulnerability.client.nvd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"url", "source", "tags"})
 public class Reference implements Serializable {
 

--- a/vulnz/README.md
+++ b/vulnz/README.md
@@ -12,7 +12,7 @@ After running `install` you may need to restart your shell for the completion to
 ```bash
 ./gradlew vulnz:build
 cd vulnz/build/libs
-./vulnz-6.0.1.jar install
+./vulnz-6.0.2.jar install
 vulnz cve --cveId CVE-2021-44228 --prettyPrint
 ```
 
@@ -76,7 +76,7 @@ export JAVA_OPTS="-Xmx2g"
 Alternatively, run the CLI using the `-Xmx2g` argument:
 
 ```bash
-java -Xmx2g -jar ./vulnz-6.0.1.jar
+java -Xmx2g -jar ./vulnz-6.0.2.jar
 ```
 
 ### Creating the Cache
@@ -91,7 +91,7 @@ vulnz cve --cache --directory ./cache
 Alternatively, without using the above install command:
 
 ```bash
-./vulnz-6.0.1.jar cve --cache --directory ./cache
+./vulnz-6.0.2.jar cve --cache --directory ./cache
 ```
 
 When creating the cache all other arguments to the vulnz cli
@@ -112,16 +112,16 @@ There are a couple of ENV vars
 
 ```bash
 # replace the NVD_API_KEY with your NVD api key
-docker run --name vulnz -e NVD_API_KEY=myapikey jeremylong/open-vulnerability-data-mirror:6.0.1 
+docker run --name vulnz -e NVD_API_KEY=myapikey jeremylong/open-vulnerability-data-mirror:6.0.2 
 
 # if you like use a volume 
-docker run --name vulnz -e NVD_API_KEY=myapikey -v cache:/usr/local/apache2/htdocs ghcr.io/jeremylong/vulnz:6.0.1
+docker run --name vulnz -e NVD_API_KEY=myapikey -v cache:/usr/local/apache2/htdocs ghcr.io/jeremylong/vulnz:6.0.2
 
 # adjust the memory usage
-docker run --name vulnz -e JAVA_OPT=-Xmx2g jeremylong/open-vulnerability-data-mirror:6.0.1
+docker run --name vulnz -e JAVA_OPT=-Xmx2g jeremylong/open-vulnerability-data-mirror:6.0.2
 
 # you can also adjust the delay 
-docker run --name vulnz -e NVD_API_KEY=myapikey -e DELAY=3000 jeremylong/open-vulnerability-data-mirror:6.0.1 
+docker run --name vulnz -e NVD_API_KEY=myapikey -e DELAY=3000 jeremylong/open-vulnerability-data-mirror:6.0.2 
 
 ```
 
@@ -133,10 +133,10 @@ docker exec -u mirror vulnz /mirror.sh
 
 ### Build
 
-Assuming the current version is `6.0.1`
+Assuming the current version is `6.0.2`
 
 ```bash
-export TARGET_VERSION=6.0.1
+export TARGET_VERSION=6.0.2
 ./gradlew vulnz:build -Pversion=$TARGET_VERSION
 docker build vulnz/ -t ghcr.io/jeremylong/vulnz:$TARGET_VERSION --build-arg BUILD_VERSION=$TARGET_VERSION
 ```
@@ -145,7 +145,7 @@ docker build vulnz/ -t ghcr.io/jeremylong/vulnz:$TARGET_VERSION --build-arg BUIL
 
 ```bash
 # checkout the repo
-git tag vulnz/6.0.1
+git tag vulnz/6.0.2
 git push --tags
-# this will build vulnz 6.0.1 on publish the docker image tagged 6.0.1 
+# this will build vulnz 6.0.2 on publish the docker image tagged 6.0.2 
 ```


### PR DESCRIPTION
As noted in https://github.com/jeremylong/DependencyCheck/issues/6747 NVD have added `cvssMetricV40` to their API which breaks this library as it is using strict deserialisation in many places it shouldnt.

This change helps workaround/fix https://github.com/jeremylong/DependencyCheck/issues/6747 and https://github.com/jeremylong/DependencyCheck/issues/6746 in the short term, before #163 is implemented.