### PR TITLE
fix: allow lenient parsing of CvssV4Data

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4Data.java
@@ -18,6 +18,7 @@ package io.github.jeremylong.openvulnerability.client.nvd;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -35,6 +36,7 @@ import java.util.Objects;
  * JSON Schema for Common Vulnerability Scoring System version 3.0
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 // TODO fix the order - added entries that aren't here
 @JsonPropertyOrder({"version", "vectorString", "attackVector", "attackComplexity", "attackRequirements",
         "privilegesRequired", "userInteraction", "vulnerableSystemConfidentiality", "vulnerableSystemIntegrity",


### PR DESCRIPTION
Follow-up to #170 

The schema does not prohibit additional properties being added:
https://github.com/jeremylong/Open-Vulnerability-Project/blob/83189a18225029b1cb535f747e6b7662acfd0ecd/open-vulnerability-clients/src/main/resources/json/cvss-v4.0.json

This will be more robust if NVD add yet new crazy things, or rename the misnamed properties back where they should be....