### PR TITLE
Add cveTags property

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
@@ -235,6 +235,7 @@ public class CveItem implements Serializable {
      * @return cveTags
      */
     @JsonProperty("cveTags")
+    @SuppressFBWarnings(value = {"EI_EXPOSE_REP"}, justification = "I prefer to suppress these FindBugs warnings")
     public List<CveTag> getCveTags() {
         return cveTags;
     }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"id", "sourceIdentifier", "published", "lastModified", "vulnStatus", "evaluatorComment",
         "evaluatorSolution", "evaluatorImpact", "cisaExploitAdd", "cisaActionDue", "cisaRequiredAction",
-        "cisaVulnerabilityName", "descriptions", "vendorComments", "metrics", "weaknesses", "configurations",
+        "cisaVulnerabilityName", "cveTags", "descriptions", "vendorComments", "metrics", "weaknesses", "configurations",
         "references"})
 public class CveItem implements Serializable {
 
@@ -79,6 +79,8 @@ public class CveItem implements Serializable {
     private String cisaRequiredAction;
     @JsonProperty("cisaVulnerabilityName")
     private String cisaVulnerabilityName;
+    @JsonProperty("cveTags")
+    private List<CveTag> cveTags;
     /**
      * (Required)
      */
@@ -107,7 +109,7 @@ public class CveItem implements Serializable {
     public CveItem(String id, String sourceIdentifier, String vulnStatus, ZonedDateTime published,
             ZonedDateTime lastModified, String evaluatorComment, String evaluatorSolution, String evaluatorImpact,
             LocalDate cisaExploitAdd, LocalDate cisaActionDue, String cisaRequiredAction, String cisaVulnerabilityName,
-            List<LangString> descriptions, List<Reference> references, Metrics metrics, List<Weakness> weaknesses,
+            List<CveTag> cveTags, List<LangString> descriptions, List<Reference> references, Metrics metrics, List<Weakness> weaknesses,
             List<Config> configurations, List<VendorComment> vendorComments) {
         this.id = id;
         this.sourceIdentifier = sourceIdentifier;
@@ -121,6 +123,7 @@ public class CveItem implements Serializable {
         this.cisaActionDue = cisaActionDue;
         this.cisaRequiredAction = cisaRequiredAction;
         this.cisaVulnerabilityName = cisaVulnerabilityName;
+        this.cveTags = cveTags;
         this.descriptions = descriptions;
         this.references = references;
         this.metrics = metrics;
@@ -229,6 +232,14 @@ public class CveItem implements Serializable {
     }
 
     /**
+     * @return cveTags
+     */
+    @JsonProperty("cveTags")
+    public List<CveTag> getCveTags() {
+        return cveTags;
+    }
+
+    /**
      * (Required)
      *
      * @return descriptions
@@ -299,7 +310,7 @@ public class CveItem implements Serializable {
                 + ", evaluatorComment='" + evaluatorComment + '\'' + ", evaluatorSolution='" + evaluatorSolution + '\''
                 + ", evaluatorImpact='" + evaluatorImpact + '\'' + ", cisaExploitAdd=" + cisaExploitAdd
                 + ", cisaActionDue=" + cisaActionDue + ", cisaRequiredAction='" + cisaRequiredAction + '\''
-                + ", cisaVulnerabilityName='" + cisaVulnerabilityName + '\'' + ", descriptions=" + descriptions
+                + ", cisaVulnerabilityName='" + cisaVulnerabilityName + '\'' + ", cveTags=" + cveTags + ", descriptions=" + descriptions
                 + ", references=" + references + ", metrics=" + metrics + ", weaknesses=" + weaknesses
                 + ", configurations=" + configurations + ", vendorComments=" + vendorComments + '}';
     }
@@ -321,6 +332,7 @@ public class CveItem implements Serializable {
                 && Objects.equals(cisaActionDue, cveItem.cisaActionDue)
                 && Objects.equals(cisaRequiredAction, cveItem.cisaRequiredAction)
                 && Objects.equals(cisaVulnerabilityName, cveItem.cisaVulnerabilityName)
+                && Objects.equals(cveTags, cveItem.cveTags)
                 && Objects.equals(descriptions, cveItem.descriptions) && Objects.equals(references, cveItem.references)
                 && Objects.equals(metrics, cveItem.metrics) && Objects.equals(weaknesses, cveItem.weaknesses)
                 && Objects.equals(configurations, cveItem.configurations)
@@ -331,6 +343,6 @@ public class CveItem implements Serializable {
     public int hashCode() {
         return Objects.hash(id, sourceIdentifier, vulnStatus, published, lastModified, evaluatorComment,
                 evaluatorSolution, evaluatorImpact, cisaExploitAdd, cisaActionDue, cisaRequiredAction,
-                cisaVulnerabilityName, descriptions, references, metrics, weaknesses, configurations, vendorComments);
+                cisaVulnerabilityName, cveTags, descriptions, references, metrics, weaknesses, configurations, vendorComments);
     }
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
@@ -109,8 +109,8 @@ public class CveItem implements Serializable {
     public CveItem(String id, String sourceIdentifier, String vulnStatus, ZonedDateTime published,
             ZonedDateTime lastModified, String evaluatorComment, String evaluatorSolution, String evaluatorImpact,
             LocalDate cisaExploitAdd, LocalDate cisaActionDue, String cisaRequiredAction, String cisaVulnerabilityName,
-            List<CveTag> cveTags, List<LangString> descriptions, List<Reference> references, Metrics metrics, List<Weakness> weaknesses,
-            List<Config> configurations, List<VendorComment> vendorComments) {
+            List<CveTag> cveTags, List<LangString> descriptions, List<Reference> references, Metrics metrics,
+            List<Weakness> weaknesses, List<Config> configurations, List<VendorComment> vendorComments) {
         this.id = id;
         this.sourceIdentifier = sourceIdentifier;
         this.vulnStatus = vulnStatus;
@@ -310,9 +310,10 @@ public class CveItem implements Serializable {
                 + ", evaluatorComment='" + evaluatorComment + '\'' + ", evaluatorSolution='" + evaluatorSolution + '\''
                 + ", evaluatorImpact='" + evaluatorImpact + '\'' + ", cisaExploitAdd=" + cisaExploitAdd
                 + ", cisaActionDue=" + cisaActionDue + ", cisaRequiredAction='" + cisaRequiredAction + '\''
-                + ", cisaVulnerabilityName='" + cisaVulnerabilityName + '\'' + ", cveTags=" + cveTags + ", descriptions=" + descriptions
-                + ", references=" + references + ", metrics=" + metrics + ", weaknesses=" + weaknesses
-                + ", configurations=" + configurations + ", vendorComments=" + vendorComments + '}';
+                + ", cisaVulnerabilityName='" + cisaVulnerabilityName + '\'' + ", cveTags=" + cveTags
+                + ", descriptions=" + descriptions + ", references=" + references + ", metrics=" + metrics
+                + ", weaknesses=" + weaknesses + ", configurations=" + configurations + ", vendorComments="
+                + vendorComments + '}';
     }
 
     @Override
@@ -332,9 +333,9 @@ public class CveItem implements Serializable {
                 && Objects.equals(cisaActionDue, cveItem.cisaActionDue)
                 && Objects.equals(cisaRequiredAction, cveItem.cisaRequiredAction)
                 && Objects.equals(cisaVulnerabilityName, cveItem.cisaVulnerabilityName)
-                && Objects.equals(cveTags, cveItem.cveTags)
-                && Objects.equals(descriptions, cveItem.descriptions) && Objects.equals(references, cveItem.references)
-                && Objects.equals(metrics, cveItem.metrics) && Objects.equals(weaknesses, cveItem.weaknesses)
+                && Objects.equals(cveTags, cveItem.cveTags) && Objects.equals(descriptions, cveItem.descriptions)
+                && Objects.equals(references, cveItem.references) && Objects.equals(metrics, cveItem.metrics)
+                && Objects.equals(weaknesses, cveItem.weaknesses)
                 && Objects.equals(configurations, cveItem.configurations)
                 && Objects.equals(vendorComments, cveItem.vendorComments);
     }
@@ -343,6 +344,7 @@ public class CveItem implements Serializable {
     public int hashCode() {
         return Objects.hash(id, sourceIdentifier, vulnStatus, published, lastModified, evaluatorComment,
                 evaluatorSolution, evaluatorImpact, cisaExploitAdd, cisaActionDue, cisaRequiredAction,
-                cisaVulnerabilityName, cveTags, descriptions, references, metrics, weaknesses, configurations, vendorComments);
+                cisaVulnerabilityName, cveTags, descriptions, references, metrics, weaknesses, configurations,
+                vendorComments);
     }
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveTag.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveTag.java
@@ -1,0 +1,126 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023-2024 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.openvulnerability.client.nvd;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"sourceIdentifier", "tags"})
+public class CveTag implements Serializable {
+    private static final long serialVersionUID = 6119071096772721680L;
+
+    /**
+     * The email address or UUID of the source that contributed the information
+     */
+    @JsonProperty("sourceIdentifier")
+    private String sourceIdentifier;
+
+    @JsonProperty("tags")
+    private List<TagType> tags;
+
+    public CveTag() {
+    }
+
+    public CveTag(String sourceIdentifier, List<TagType> tags) {
+        this.sourceIdentifier = sourceIdentifier;
+        this.tags = tags;
+    }
+
+    /**
+     * @return sourceIdentifier
+     */
+    public String getSourceIdentifier() {
+        return sourceIdentifier;
+    }
+
+    /**
+     * @return tags
+     */
+    public List<TagType> getTags() {
+        return tags;
+    }
+
+    @Override
+    public String toString() {
+        return "CveTag{" +
+                "sourceIdentifier='" + sourceIdentifier + '\'' +
+                ", tags=" + tags +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CveTag cveTag = (CveTag) o;
+        return Objects.equals(sourceIdentifier, cveTag.sourceIdentifier) && Objects.equals(tags, cveTag.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sourceIdentifier, tags);
+    }
+
+    public enum TagType {
+        UNSUPPORTED_WHEN_ASSIGNED("unsupported-when-assigned"), EXCLUSIVELY_HOSTED_SERVICE("exclusively-hosted-service"), DISPUTED("disputed");
+
+        private final static Map<String, TagType> CONSTANTS = new HashMap<>();
+
+        static {
+            for (TagType c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        private final String value;
+
+        TagType(String value) {
+            this.value = value;
+        }
+
+        @JsonCreator
+        public static TagType fromValue(String value) {
+            TagType constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonValue
+        public String value() {
+            return this.value;
+        }
+    }
+}

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveTag.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveTag.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ public class CveTag implements Serializable {
     public CveTag() {
     }
 
+    @SuppressFBWarnings(value = {"EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")
     public CveTag(String sourceIdentifier, List<TagType> tags) {
         this.sourceIdentifier = sourceIdentifier;
         this.tags = tags;
@@ -53,6 +55,7 @@ public class CveTag implements Serializable {
     /**
      * @return sourceIdentifier
      */
+    @JsonProperty("sourceIdentifier")
     public String getSourceIdentifier() {
         return sourceIdentifier;
     }
@@ -60,6 +63,8 @@ public class CveTag implements Serializable {
     /**
      * @return tags
      */
+    @JsonProperty("tags")
+    @SuppressFBWarnings(value = {"EI_EXPOSE_REP"}, justification = "I prefer to suppress these FindBugs warnings")
     public List<TagType> getTags() {
         return tags;
     }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveTag.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveTag.java
@@ -66,16 +66,15 @@ public class CveTag implements Serializable {
 
     @Override
     public String toString() {
-        return "CveTag{" +
-                "sourceIdentifier='" + sourceIdentifier + '\'' +
-                ", tags=" + tags +
-                '}';
+        return "CveTag{" + "sourceIdentifier='" + sourceIdentifier + '\'' + ", tags=" + tags + '}';
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
 
         CveTag cveTag = (CveTag) o;
         return Objects.equals(sourceIdentifier, cveTag.sourceIdentifier) && Objects.equals(tags, cveTag.tags);
@@ -87,7 +86,8 @@ public class CveTag implements Serializable {
     }
 
     public enum TagType {
-        UNSUPPORTED_WHEN_ASSIGNED("unsupported-when-assigned"), EXCLUSIVELY_HOSTED_SERVICE("exclusively-hosted-service"), DISPUTED("disputed");
+        UNSUPPORTED_WHEN_ASSIGNED("unsupported-when-assigned"), EXCLUSIVELY_HOSTED_SERVICE(
+                "exclusively-hosted-service"), DISPUTED("disputed");
 
         private final static Map<String, TagType> CONSTANTS = new HashMap<>();
 


### PR DESCRIPTION
- https://github.com/jeremylong/Open-Vulnerability-Project/pull/151

Disputed information is now only included in cveTags.
Fixed to include cveTags

<img width="764" alt="スクリーンショット 2024-06-30 23 08 34" src="https://github.com/jeremylong/Open-Vulnerability-Project/assets/8900042/2374be72-2d15-413f-80db-5cecc8f102d4">

