### PR TITLE
fix: prevent memory leak 

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -331,7 +331,8 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
 
     private Collection<DefCveItem> _next(int retryCount) {
         if (retryCount > 5) {
-            throw new NvdApiRetryExceededException("NVD Update Failed: attempted to retrieve data from the NVD unsuccessfully five times.");
+            throw new NvdApiRetryExceededException(
+                    "NVD Update Failed: attempted to retrieve data from the NVD unsuccessfully five times.");
         }
         if (firstCall) {
             futures.add(callApi(0, 0));

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -326,6 +326,13 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      */
     @Override
     public Collection<DefCveItem> next() {
+        return _next(0);
+    }
+
+    private Collection<DefCveItem> _next(int retryCount) {
+        if (retryCount > 5) {
+            throw new NvdApiRetryExceededException("NVD Update Failed: attempted to retrieve data from the NVD unsuccessfully five times.");
+        }
         if (firstCall) {
             futures.add(callApi(0, 0));
         }
@@ -335,7 +342,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             call = getCompletedFuture();
             if (call == null) {
                 if (hasNext()) {
-                    return next();
+                    return _next(retryCount + 1);
                 }
             } else {
                 SimpleHttpResponse response = call.getResponse();
@@ -354,7 +361,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                     } catch (JsonProcessingException e) {
                         LOG.debug("Error processing NVD data", e);
                         // Re-try on what might be temporarily streaming errors
-                        return next();
+                        return _next(retryCount + 1);
                     }
                     this.totalAvailable = current.getTotalResults();
                     lastUpdated = findLastUpdated(lastUpdated, current.getVulnerabilities());
@@ -381,7 +388,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             // in rare cases we get an error from the NVD - log the error and only fail if we retry too many times
             LOG.debug("Error retrieving the NVD data", e);
             if (hasNext()) {
-                return next();
+                return _next(retryCount + 1);
             }
             close();
         }


### PR DESCRIPTION
Cap recursive calls to `next()` under failure conditions.