### PR TITLE
Ensure we log cron tasks locally

### DIFF
--- a/vulnz/Dockerfile
+++ b/vulnz/Dockerfile
@@ -46,8 +46,8 @@ RUN chmod +x /mirror.sh && \
     chown mirror:mirror /mirror.sh && \
     chown mirror:mirror /usr/local/bin/vulnz 
 
-# ensures our cron task is logged into stdout of docker
-RUN ln -sf /proc/1/fd/1 /var/log/cron_mirror.log
+# ensures we can log cron task is into stdout of docker
+RUN ln -sf /proc/1/fd/1 /var/log/docker_out.log
 
 VOLUME /usr/local/apache2/htdocs
 WORKDIR /usr/local/apache2/htdocs

--- a/vulnz/src/docker/crontab/mirror
+++ b/vulnz/src/docker/crontab/mirror
@@ -1,1 +1,1 @@
-0 0 * * * /mirror.sh >> /var/log/cron_mirror.log 2>&1
+0 0 * * * /mirror.sh 2>&1 | tee -a /var/log/docker_out.log | tee -a /var/log/cron_mirror.log

--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -14,16 +14,19 @@ if [ -n "${DELAY}" ]; then
   DELAY_ARG="--delay=$DELAY"
 fi
 
+MAX_RETRY_ARG=""
 if [ -n "${MAX_RETRY}" ]; then
   echo "Using max retry attempts: $MAX_RECORDS_PER_PAGE"
   MAX_RETRY_ARG="--maxRetry=$MAX_RETRY"
 fi
 
+MAX_RECORDS_PER_PAGE_ARG=""
 if [ -n "${MAX_RECORDS_PER_PAGE}" ]; then
   echo "Using max records per page: $MAX_RECORDS_PER_PAGE"
   MAX_RECORDS_PER_PAGE_ARG="--recordsPerPage=$MAX_RECORDS_PER_PAGE"
 fi
 
+DEBUG_ARG=""
 if [ -n "${DEBUG}" ]; then
   echo "Enabling debug mode"
   DEBUG_ARG="--debug"


### PR DESCRIPTION
This will help analyzing cron issues since docker stdout is also flooded by access logs and the last cron task output is hardly every visible