### PR TITLE
fix: Correctly log MAX_RETRY

### DIFF
--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -16,7 +16,7 @@ fi
 
 MAX_RETRY_ARG=""
 if [ -n "${MAX_RETRY}" ]; then
-  echo "Using max retry attempts: $MAX_RECORDS_PER_PAGE"
+  echo "Using max retry attempts: $MAX_RETRY"
   MAX_RETRY_ARG="--maxRetry=$MAX_RETRY"
 fi
 


### PR DESCRIPTION
Fixed a typo, so now the max retry attempts gets logged correctly in the docker script.