### PR TITLE
#230 & #232 Improve cache validation logic in mirror.sh script

### DIFF
--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -34,10 +34,12 @@ fi
 
 java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs
 
-echo "Valdiating the cache..."
-
-if ! find /usr/local/apache2/htdocs -name "*.gz" -type f -exec gzip -t {} \; ; then
-    echo "Corrupt gz files detected, clearing cache and re-running mirror"
-    rm -rf /usr/local/apache2/htdocs/*
-    java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs
-fi
+echo "Validating the cache..."
+find /usr/local/apache2/htdocs -name "*.gz" -type f | while read -r file; do
+    if ! gzip -t "$file"; then
+        echo "Corrupt gz file detected: $file, clearing cache and re-running mirror"
+        rm -rf /usr/local/apache2/htdocs/*
+        java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs
+        break
+    fi
+done

--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -35,7 +35,7 @@ fi
 java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs
 
 echo "Validating the cache..."
-find /usr/local/apache2/htdocs -name "*.gz" -type f | while read -r file; do
+for file in /usr/local/apache2/htdocs/*.gz; do
     if ! gzip -t "$file"; then
         echo "Corrupt gz file detected: $file, clearing cache and re-running mirror"
         rm -rf /usr/local/apache2/htdocs/*


### PR DESCRIPTION
Refactor the cache validation process to check each gzip file individually. If a corrupt file is detected, the script now provides the specific filename before clearing the cache and rerunning the mirror process. This change enhances error reporting.
Spelling error: Valdiating -> Validating