### PR TITLE
Monitoring for the vulnz cli (#230)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+*.conf text eol=lf

--- a/vulnz/README.md
+++ b/vulnz/README.md
@@ -107,6 +107,9 @@ There are a couple of ENV vars
 
 - `NVD_API_KEY`: define your API key
 - `DELAY`: override the delay - given in milliseconds. If you do not set an API KEY, the delay will be `10000`
+- `MAX_RETRY_ARG` Using max retry attempts
+- `MAX_RECORDS_PER_PAGE_ARG` Using max records per page
+- `METRICS_ENABLE` If is set to `true`, OpenMetrics data for the vulnz cli can be retrieved via the endpoint http://.../metrics
 
 ### Run
 

--- a/vulnz/build.gradle
+++ b/vulnz/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'jakarta.transaction:jakarta.transaction-api:2.0.1'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     implementation 'com.sun.activation:jakarta.activation:2.0.1'
+    implementation 'io.prometheus:client_java:1.3.4'
+    implementation 'io.prometheus:prometheus-metrics-exposition-formats:1.3.4'
+    implementation 'io.prometheus:prometheus-metrics-instrumentation-jvm:1.3.4'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
@@ -32,10 +32,12 @@ import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import picocli.CommandLine;
 import picocli.spring.boot.autoconfigure.PicocliAutoConfiguration;
 
 @SpringBootApplication()
+@EnableScheduling
 // speed up spring load time.
 @ImportAutoConfiguration(value = {PicocliAutoConfiguration.class}, exclude = {
         ConfigurationPropertiesAutoConfiguration.class, ProjectInfoAutoConfiguration.class,

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -77,6 +77,7 @@ public class CveCommand extends AbstractNvdCommand {
      * Hex code characters used in getHex.
      */
     private static final String HEXES = "0123456789abcdef";
+
     @CommandLine.ArgGroup(exclusive = true)
     ConfigGroup configGroup;
 
@@ -114,6 +115,14 @@ public class CveCommand extends AbstractNvdCommand {
     private NvdCveClientBuilder.CvssV3Severity cvssV3Severity;
     @CommandLine.Option(names = {"--interactive"}, description = "Displays a progress bar")
     private boolean interactive;
+
+    public File getCacheDirectory() {
+        if (configGroup != null && configGroup.cacheSettings != null) {
+            return configGroup.cacheSettings.directory;
+        } else {
+            return null;
+        }
+    }
 
     @Override
     public Integer timedCall() throws Exception {

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/monitoring/PrometheusFileWriter.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/monitoring/PrometheusFileWriter.java
@@ -1,0 +1,62 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2024 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.vulnz.cli.monitoring;
+
+import io.github.jeremylong.vulnz.cli.commands.CveCommand;
+import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@Component
+@ConditionalOnProperty(name = "metrics.enable", havingValue = "true")
+public class PrometheusFileWriter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusFileWriter.class);
+
+    @Autowired
+    private CveCommand command;
+
+    @PostConstruct
+    public void init() {
+        JvmMetrics.builder().register();
+    }
+
+    @Scheduled(fixedRate = 5000)
+    public void writeFile() {
+        File directory = command.getCacheDirectory();
+        if (directory != null) {
+            final PrometheusRegistry defaultRegistry = PrometheusRegistry.defaultRegistry;
+            try (FileOutputStream out = new FileOutputStream(new File(directory, "metrics"))) {
+                OpenMetricsTextFormatWriter writer = new OpenMetricsTextFormatWriter(true, true);
+                writer.write(out, defaultRegistry.scrape());
+            } catch (IOException e) {
+                LOG.error("Error writing metrics", e);
+            }
+        }
+    }
+}

--- a/vulnz/src/main/resources/application.properties
+++ b/vulnz/src/main/resources/application.properties
@@ -6,3 +6,5 @@ spring.application.name=nvd
 spring.main.web-application-type=none
 
 spring.main.log-startup-info=false
+application.version=@version@
+metrics.enable=false

--- a/vulnz/src/main/resources/banner.txt
+++ b/vulnz/src/main/resources/banner.txt
@@ -4,5 +4,7 @@ _/      _/   _/    _/    _/     _/    _/       _/
  _/  _/     _/    _/    _/     _/    _/     _/
   _/         _/_/_/    _/     _/    _/   _/_/_/_/
 
+Version: ${AnsiColor.GREEN}${application.version}${AnsiColor.DEFAULT}
+
 Open Vulnerability Project
 💖 Sponsor: https://github.com/sponsors/jeremylong


### PR DESCRIPTION
1.) To better monitor the vulzn CLI, a scheduler has been implemented that writes metrics to the htdocs folder. These metrics can be read by a Prometheus system, for example. Metrics are only written if the vulzn CLI is also running. This feature is disabled by default and can be enabled via the ENV variable `METRICS_ENABLE=true`. This is used for better analysis of memory issues. The metrics can be accessed via HTTP at /metrics. This additional metrics file does not affect the OWASP dependency check. To achieve this, new dependencies had to be added to the project. Currently, only the standard JVM metrics are being written, but it can also be extended to include custom metrics.
![image](https://github.com/user-attachments/assets/c003450f-1625-4957-8f7d-e3212a5466f3)
![image](https://github.com/user-attachments/assets/9680b463-a68a-4c7e-8cac-18ccfdcde8b1)

2.) As an additional improvement to track version changes based on the log, the banner was extended to include the version number.
![image](https://github.com/user-attachments/assets/9c691051-fa3a-4d57-999b-cd5e1395477b)

3.) .gitattribute added for building the docker image under Windows OS, because of CRLF and LF problems

4.) readme.md Configuration extended with missing ENV vars.
![image](https://github.com/user-attachments/assets/c18ed95c-17e2-4b85-b9e3-16d629db2eac)
