### PR TITLE
Monitoring bug fixes and enhancements

### DIFF
--- a/vulnz/README.md
+++ b/vulnz/README.md
@@ -79,6 +79,11 @@ Alternatively, run the CLI using the `-Xmx2g` argument:
 java -Xmx2g -jar ./vulnz-7.1.0.jar
 ```
 
+An option to save memory would be: `-XX:+UseStringDeduplication`:
+```bash
+export JAVA_OPTS="-Xmx2g -XX:+UseStringDeduplication"
+```
+
 ### Creating the Cache
 
 To create a local cache of the NVD CVE Data you can execute the following command
@@ -110,6 +115,7 @@ There are a couple of ENV vars
 - `MAX_RETRY_ARG` Using max retry attempts
 - `MAX_RECORDS_PER_PAGE_ARG` Using max records per page
 - `METRICS_ENABLE` If is set to `true`, OpenMetrics data for the vulnz cli can be retrieved via the endpoint http://.../metrics
+- `METRICS_WRITE_INTERVAL` Sets the update interval for generating metrics. Default: `5000`
 
 ### Run
 

--- a/vulnz/README.md
+++ b/vulnz/README.md
@@ -115,7 +115,7 @@ There are a couple of ENV vars
 - `MAX_RETRY_ARG` Using max retry attempts
 - `MAX_RECORDS_PER_PAGE_ARG` Using max records per page
 - `METRICS_ENABLE` If is set to `true`, OpenMetrics data for the vulnz cli can be retrieved via the endpoint http://.../metrics
-- `METRICS_WRITE_INTERVAL` Sets the update interval for generating metrics. Default: `5000`
+- `METRICS_WRITE_INTERVAL` Sets the update interval for generating metrics, in milliseconds. Default: `5000`
 
 ### Run
 

--- a/vulnz/build.gradle
+++ b/vulnz/build.gradle
@@ -30,9 +30,9 @@ dependencies {
     implementation 'jakarta.transaction:jakarta.transaction-api:2.0.1'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     implementation 'com.sun.activation:jakarta.activation:2.0.1'
-    implementation 'io.prometheus:client_java:1.3.4'
-    implementation 'io.prometheus:prometheus-metrics-exposition-formats:1.3.4'
-    implementation 'io.prometheus:prometheus-metrics-instrumentation-jvm:1.3.4'
+    implementation 'io.prometheus:client_java:1.3.5'
+    implementation 'io.prometheus:prometheus-metrics-exposition-formats:1.3.5'
+    implementation 'io.prometheus:prometheus-metrics-instrumentation-jvm:1.3.5'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
@@ -34,7 +34,6 @@ import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import picocli.CommandLine;
 import picocli.spring.boot.autoconfigure.PicocliAutoConfiguration;
@@ -42,7 +41,7 @@ import picocli.spring.boot.autoconfigure.PicocliAutoConfiguration;
 @SpringBootApplication()
 @EnableScheduling
 // speed up spring load time.
-@ImportAutoConfiguration(value = {PicocliAutoConfiguration.class, TaskSchedulingAutoConfiguration.class}, exclude = {
+@ImportAutoConfiguration(value = {PicocliAutoConfiguration.class}, exclude = {
         ConfigurationPropertiesAutoConfiguration.class, ProjectInfoAutoConfiguration.class,
         PropertyPlaceholderAutoConfiguration.class, LifecycleAutoConfiguration.class,
         ApplicationAvailabilityAutoConfiguration.class, AopAutoConfiguration.class, JacksonAutoConfiguration.class,

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
@@ -55,6 +55,9 @@ public class Application implements CommandLineRunner, ExitCodeGenerator {
     @Value("${application.version:0.0.0}")
     private String applicationVersion;
 
+    @Value("${spring.application.name:nvd}")
+    private String applicationName;
+
     Application(CommandLine.IFactory factory, MainCommand command) {
         this.factory = factory;
         this.command = command;
@@ -75,7 +78,12 @@ public class Application implements CommandLineRunner, ExitCodeGenerator {
 
     @Override
     public void run(String... args) {
-        Counter.builder().name("version").help("The project version").constLabels(Labels.of("version", applicationVersion)).register();
+        Counter.builder().name("application")
+                .help("Information about the current project version and name")
+                .constLabels(Labels.of("version", applicationVersion, "name", applicationName))
+                .register()
+                .inc();
+
         // add extra line to make output more readable
         System.err.println();
         exitCode = new CommandLine(command, factory).setCaseInsensitiveEnumValuesAllowed(true).execute(args);

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
@@ -77,11 +77,8 @@ public class Application implements CommandLineRunner, ExitCodeGenerator {
 
     @Override
     public void run(String... args) {
-        Counter.builder().name("application")
-                .help("Information about the current project version and name")
-                .constLabels(Labels.of("version", applicationVersion, "name", applicationName))
-                .register()
-                .inc();
+        Counter.builder().name("application").help("Information about the current project version and name")
+                .constLabels(Labels.of("version", applicationVersion, "name", applicationName)).register().inc();
 
         // add extra line to make output more readable
         System.err.println();

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -79,8 +79,10 @@ public class CveCommand extends AbstractNvdCommand {
      */
     private static final String HEXES = "0123456789abcdef";
 
-    private static final Gauge CVE_LOAD_COUNTER = Gauge.builder().name("cve_load_counter").help("Total number of loaded cve's").register();
-    private static final Gauge CVE_COUNTER = Gauge.builder().name("cve_counter").help("Total number of cached cve's").register();
+    private static final Gauge CVE_LOAD_COUNTER = Gauge.builder().name("cve_load_counter")
+            .help("Total number of loaded cve's").register();
+    private static final Gauge CVE_COUNTER = Gauge.builder().name("cve_counter").help("Total number of cached cve's")
+            .register();
 
     @CommandLine.ArgGroup(exclusive = true)
     ConfigGroup configGroup;

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -257,7 +257,7 @@ public class CveCommand extends AbstractNvdCommand {
         return processRequest(builder);
     }
 
-    private Integer processRequest(NvdCveClientBuilder builder, CacheProperties properties) throws InterruptedException {
+    private Integer processRequest(NvdCveClientBuilder builder, CacheProperties properties) {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         if (isPrettyPrint()) {
@@ -276,7 +276,6 @@ public class CveCommand extends AbstractNvdCommand {
                         GZIPInputStream gzipInputStream = new GZIPInputStream(fileInputStream)) {
                     data = objectMapper.readValue(gzipInputStream, CveApiJson20.class);
                 } catch (IOException exception) {
-                    Thread.sleep(10000);
                     throw new CacheException("Unable to read cached data: " + file, exception);
                 }
                 collectCves(cves, data.getVulnerabilities());

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/monitoring/PrometheusFileWriter.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/monitoring/PrometheusFileWriter.java
@@ -46,7 +46,7 @@ public class PrometheusFileWriter {
         JvmMetrics.builder().register();
     }
 
-    @Scheduled(fixedRate = 5000)
+    @Scheduled(fixedRateString = "${metrics.write.interval:5000}")
     public void writeFile() {
         File directory = command.getCacheDirectory();
         if (directory != null) {

--- a/vulnz/src/main/resources/application.properties
+++ b/vulnz/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.main.web-application-type=none
 spring.main.log-startup-info=false
 application.version=@version@
 metrics.enable=false
+metrics.write.interval=5000


### PR DESCRIPTION
Bugfix: Remove _TaskSchedulingAutoConfiguration.class_ from the exclude list to ensure that the scheduler for writing metrics is also started.
Introduce a new property: `metrics.write.interval.` This allows you to configure the invocation interval for writing metrics.
Update the documentation accordingly:
![image](https://github.com/user-attachments/assets/eeec85cf-4d93-4ffd-aa33-d314d2d05b69)
![image](https://github.com/user-attachments/assets/46b01018-8869-493a-b27a-3ffef7473ece)

New metrics added:
````
# TYPE application counter
# HELP application Information about the current project version and name
application_total{name="nvd",version="7.1.0"} 1.0
application_created{name="nvd",version="7.1.0"} 1734819109.346
# TYPE cve_counter gauge
# HELP cve_counter Total number of cached cve's
cve_counter 243324.0
# TYPE cve_load_counter gauge
# HELP cve_load_counter Total number of loaded cve's
cve_load_counter 1.0
````
