### PR TITLE
Fix kill signal handling #244

### DIFF
--- a/vulnz/Dockerfile
+++ b/vulnz/Dockerfile
@@ -7,7 +7,7 @@ ARG http_proxy
 ARG https_proxy
 ARG no_proxy
 
-LABEL authors="derhecht,stevespringett,jeremylong"
+LABEL authors="derhecht,stevespringett,jeremylong,eugenmayer"
 LABEL maintainer="jeremy.long@gmail.com"
 LABEL name="jeremylong/vulnz"
 LABEL version=$BUILD_VERSION
@@ -37,13 +37,15 @@ RUN apk update && \
 
 COPY ["/src/docker/supervisor/supervisord.conf", "/etc/supervisord.conf"]
 COPY ["/src/docker/scripts/mirror.sh", "/mirror.sh"]
+COPY ["/src/docker/scripts/validate.sh", "/validate.sh"]
 COPY ["/src/docker/crontab/mirror", "/etc/crontabs/mirror"]
+COPY ["/src/docker/crontab/validate", "/etc/crontabs/validate"]
 COPY ["/src/docker/apache/mirror.conf", "/usr/local/apache2/conf"]
 COPY ["/build/libs/vulnz-$BUILD_VERSION.jar", "/usr/local/bin/vulnz"]
 
-RUN chmod +x /mirror.sh && \
-    chown root:root /etc/crontabs/mirror && \
-    chown mirror:mirror /mirror.sh && \
+RUN chmod +x /mirror.sh /validate.sh && \
+    chown root:root /etc/crontabs/mirror /etc/crontabs/validate && \
+    chown mirror:mirror /mirror.sh /validate.sh && \
     chown mirror:mirror /usr/local/bin/vulnz 
 
 # ensures we can log cron task is into stdout of docker

--- a/vulnz/src/docker/crontab/validate
+++ b/vulnz/src/docker/crontab/validate
@@ -1,0 +1,1 @@
+0 4 * * * /validate.sh 2>&1 | tee -a /var/log/docker_out.log | tee -a /var/log/cron_validate.log

--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
-
-function shutdown () {
-  exit 0
-}
-
-trap shutdown HUP INT QUIT ABRT KILL ALRM TERM TSTP
+set -e
 
 echo "Updating..."
 
@@ -38,15 +33,5 @@ if [ -n "${DEBUG}" ]; then
   DEBUG_ARG="--debug"
 fi
 
-java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs
-
-echo "Validating the cache..."
-for file in /usr/local/apache2/htdocs/*.gz; do
-    if ! gzip -t "$file"; then
-        echo "Corrupt gz file detected: $file, clearing cache and re-running mirror"
-        rm -rf /usr/local/apache2/htdocs/*
-        java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs
-        break
-    fi
-done
+exec java $JAVA_OPT -jar /usr/local/bin/vulnz cve $DELAY_ARG $DEBUG_ARG $MAX_RETRY_ARG $MAX_RECORDS_PER_PAGE_ARG --cache --directory /usr/local/apache2/htdocs
 

--- a/vulnz/src/docker/scripts/mirror.sh
+++ b/vulnz/src/docker/scripts/mirror.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+function shutdown () {
+  exit 0
+}
+
+trap shutdown HUP INT QUIT ABRT KILL ALRM TERM TSTP
+
 echo "Updating..."
 
 DELAY_ARG=""
@@ -43,3 +49,4 @@ for file in /usr/local/apache2/htdocs/*.gz; do
         break
     fi
 done
+

--- a/vulnz/src/docker/scripts/validate.sh
+++ b/vulnz/src/docker/scripts/validate.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Validating the cache..."
+for file in /usr/local/apache2/htdocs/*.gz; do
+    if ! gzip -t "$file"; then
+        echo "Corrupt gz file detected: $file, clearing cache and re-running mirror"
+        rm -rf /usr/local/apache2/htdocs/*
+        supervisorctl start init_nvd_cache
+        break
+    fi
+done
+


### PR DESCRIPTION
Fixes #244 

- use exec to replace the bash script, not fork a different process
- use dedicated validate process