### PR TITLE
Add SecurityAdvisory cvssSeverities and deprecate cvss

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSSSeverities.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSSSeverities.java
@@ -1,3 +1,19 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023-2025 Jeremy Long. All Rights Reserved.
+ */
 package io.github.jeremylong.openvulnerability.client.ghsa;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSSSeverities.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSSSeverities.java
@@ -1,0 +1,52 @@
+package io.github.jeremylong.openvulnerability.client.ghsa;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * The Common Vulnerability Scoring System
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CVSSSeverities implements Serializable {
+
+    private static final long serialVersionUID = -6425427956203326377L;
+
+    @JsonProperty("cvssV3")
+    private CVSS cvssV3;
+
+    @JsonProperty("cvssV4")
+    private CVSS cvssV4;
+
+    public CVSS getCvssV3() {
+        return cvssV3;
+    }
+
+    public CVSS getCvssV4() {
+        return cvssV4;
+    }
+
+    @Override
+    public String toString() {
+        return "CVSSSeverities{" + "cvssV3=" + cvssV3 + ", cvssV4=" + cvssV4 + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        CVSSSeverities cvss = (CVSSSeverities) o;
+        return cvssV3.equals(cvss.cvssV3) && cvssV4.equals(cvss.cvssV4);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cvssV3, cvssV4);
+    }
+}

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSSSeverities.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/CVSSSeverities.java
@@ -3,6 +3,7 @@ package io.github.jeremylong.openvulnerability.client.ghsa;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -12,6 +13,7 @@ import java.util.Objects;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"cvssV3", "cvssV4"})
 public class CVSSSeverities implements Serializable {
 
     private static final long serialVersionUID = -6425427956203326377L;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"databaseId", "description", "ghsaId", "id", "identifiers", "notificationsPermalink", "origin",
         "permalink", "publishedAt", "references", "severity", "summary", "updatedAt", "vulnerabilities",
-        "classification", "cvss", "cwes", "withdrawnAt"})
+        "classification", "cvss", "cvssSeverities", "cwes", "withdrawnAt"})
 public class SecurityAdvisory implements Serializable {
 
     /**
@@ -86,8 +86,15 @@ public class SecurityAdvisory implements Serializable {
     @JsonProperty("classification")
     private String classification;
 
+    // https://docs.github.com/en/graphql/overview/breaking-changes#changes-scheduled-for-2025-10-01
+    // cvss will be removed at  2025-10-01.
+    // New cvssSeverities field will now contain both cvssV3 and cvssV4 properties.
+    @Deprecated(forRemoval = true)
     @JsonProperty("cvss")
     private CVSS cvss;
+
+    @JsonProperty("cvssSeverities")
+    private CVSSSeverities cvssSeverities;
 
     @JsonProperty(value = "cwes")
     private CWEs cwes;
@@ -239,8 +246,18 @@ public class SecurityAdvisory implements Serializable {
      *
      * @return the CVSS associated with this advisory.
      */
+    @Deprecated(forRemoval = true)
     public CVSS getCvss() {
         return cvss;
+    }
+
+    /**
+     *  The CVSS associated with this advisory.
+     *
+     * @return the CVSS associated with this advisory.
+     */
+    public CVSSSeverities getCvssSeverities() {
+        return cvssSeverities;
     }
 
     /**
@@ -272,8 +289,8 @@ public class SecurityAdvisory implements Serializable {
                 + notificationsPermalink + '\'' + ", origin='" + origin + '\'' + ", permalink='" + permalink + '\''
                 + ", publishedAt=" + publishedAt + ", references=" + references + ", severity=" + severity
                 + ", summary='" + summary + '\'' + ", updatedAt=" + updatedAt + ", withdrawnAt=" + withdrawnAt
-                + ", classification=" + classification + ", cvss=" + cvss + ", cwes=" + cwes + ", vulnerabilities="
-                + vulnerabilities + '}';
+                + ", classification=" + classification + ", cvss=" + cvss + ", cvssSeverities=" + cvssSeverities
+                + ", cwes=" + cwes + ", vulnerabilities=" + vulnerabilities + '}';
     }
 
     @Override
@@ -292,13 +309,14 @@ public class SecurityAdvisory implements Serializable {
                 && severity == that.severity && Objects.equals(summary, that.summary)
                 && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(withdrawnAt, that.withdrawnAt)
                 && Objects.equals(classification, that.classification) && Objects.equals(cvss, that.cvss)
+                && Objects.equals(cvssSeverities, that.cvssSeverities)
                 && Objects.equals(cwes, that.cwes) && Objects.equals(vulnerabilities, that.vulnerabilities);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(databaseId, description, ghsaId, id, identifiers, notificationsPermalink, origin, permalink,
-                publishedAt, references, severity, summary, updatedAt, withdrawnAt, classification, cvss, cwes,
-                vulnerabilities);
+                publishedAt, references, severity, summary, updatedAt, withdrawnAt, classification, cvss,
+                cvssSeverities, cwes, vulnerabilities);
     }
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
@@ -87,7 +87,7 @@ public class SecurityAdvisory implements Serializable {
     private String classification;
 
     // https://docs.github.com/en/graphql/overview/breaking-changes#changes-scheduled-for-2025-10-01
-    // cvss will be removed at  2025-10-01.
+    // cvss will be removed at 2025-10-01.
     // New cvssSeverities field will now contain both cvssV3 and cvssV4 properties.
     @Deprecated(forRemoval = true)
     @JsonProperty("cvss")
@@ -252,7 +252,7 @@ public class SecurityAdvisory implements Serializable {
     }
 
     /**
-     *  The CVSS associated with this advisory.
+     * The CVSS associated with this advisory.
      *
      * @return the CVSS associated with this advisory.
      */
@@ -309,8 +309,8 @@ public class SecurityAdvisory implements Serializable {
                 && severity == that.severity && Objects.equals(summary, that.summary)
                 && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(withdrawnAt, that.withdrawnAt)
                 && Objects.equals(classification, that.classification) && Objects.equals(cvss, that.cvss)
-                && Objects.equals(cvssSeverities, that.cvssSeverities)
-                && Objects.equals(cwes, that.cwes) && Objects.equals(vulnerabilities, that.vulnerabilities);
+                && Objects.equals(cvssSeverities, that.cvssSeverities) && Objects.equals(cwes, that.cwes)
+                && Objects.equals(vulnerabilities, that.vulnerabilities);
     }
 
     @Override

--- a/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
+++ b/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
@@ -57,6 +57,16 @@ query {
         score
         vectorString
       }
+      cvssSeverities {
+        cvssV3 {
+          score
+          vectorString
+        }
+        cvssV4 {
+          score
+          vectorString
+        }
+      }
       cwes(first: 50) {
         edges {
           node {


### PR DESCRIPTION
Add SecurityAdvisory `cvssSeverities` and deprecate `cvss`

https://docs.github.com/en/graphql/reference/objects#securityadvisory

> cvss is deprecated.
> cvss will be removed. New cvss_severities field will now contain both cvss_v3 and cvss_v4 properties. Removal on 2025-10-01 UTC.

CVSS v4 only exists in `cvss_severities`. The `cvss` field is deprecated as it will be removed on 2025-10-01 UTC.

https://docs.github.com/en/graphql/overview/breaking-changes#changes-scheduled-for-2025-10-01

```bash
java -jar vulnz/build/libs/vulnz-7.1.0.jar ghsa --updatedSince="2025-01-10T00:00:00Z" > result.json
```

[result.json.txt](https://github.com/user-attachments/files/18410944/result.json.txt)
