### PR TITLE
Add support for configurable metrics output format and fixes #255

### DIFF
--- a/vulnz/README.md
+++ b/vulnz/README.md
@@ -116,6 +116,7 @@ There are a couple of ENV vars
 - `MAX_RECORDS_PER_PAGE_ARG` Using max records per page
 - `METRICS_ENABLE` If is set to `true`, OpenMetrics data for the vulnz cli can be retrieved via the endpoint http://.../metrics
 - `METRICS_WRITE_INTERVAL` Sets the update interval for generating metrics, in milliseconds. Default: `5000`
+- `METRICS_WRITE_FORMAT` Sets the output format for the metrics. Either openmetrics or Prometheus format. Default: `openmetrics`
 
 ### Run
 

--- a/vulnz/build.gradle
+++ b/vulnz/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'jakarta.transaction:jakarta.transaction-api:2.0.1'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     implementation 'com.sun.activation:jakarta.activation:2.0.1'
-    implementation 'io.prometheus:client_java:1.3.5'
+    implementation 'io.prometheus:prometheus-metrics-core:1.3.5'
     implementation 'io.prometheus:prometheus-metrics-exposition-formats:1.3.5'
     implementation 'io.prometheus:prometheus-metrics-instrumentation-jvm:1.3.5'
 

--- a/vulnz/src/main/resources/application.properties
+++ b/vulnz/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.main.log-startup-info=false
 application.version=@version@
 metrics.enable=false
 metrics.write.interval=5000
+metrics.writer.format=openmetrics


### PR DESCRIPTION
Change from io.prometheus:client_java to io.prometheus:prometheus-metrics-core to fix #255

Introduced a new `METRICS_WRITE_FORMAT` property to allow switching between OpenMetrics and Prometheus formats for metric exposition. Updated relevant logic, dependencies, and documentation to support this functionality. Default remains `openmetrics`.

Prometheus versions older than 3 lack support for the OpenMetrics format.