### PR TITLE
fix: use correct types for modifiedSubAvailabilityImpact, modifiedSubIntegrityImpact, and modifiedSubConfidentialityImpact

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4Data.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4Data.java
@@ -71,8 +71,8 @@ public class CvssV4Data implements Serializable {
             ModifiedPrivilegesRequiredType modifiedPrivilegesRequired,
             ModifiedUserInteractionType modifiedUserInteraction, ModifiedCiaType modifiedVulnConfidentialityImpact,
             ModifiedCiaType modifiedVulnIntegrityImpact, ModifiedCiaType modifiedVulnAvailabilityImpact,
-            ModifiedCiaType modifiedSubConfidentialityImpact, ModifiedCiaType modifiedSubIntegrityImpact,
-            ModifiedCiaType modifiedSubAvailabilityImpact, SafetyType safety, AutomatableType automatable,
+            ModifiedSubCType modifiedSubConfidentialityImpact, ModifiedSubIaType modifiedSubIntegrityImpact,
+            ModifiedSubIaType modifiedSubAvailabilityImpact, SafetyType safety, AutomatableType automatable,
             RecoveryType recovery, ValueDensityType valueDensity,
             VulnerabilityResponseEffortType vulnerabilityResponseEffort, ProviderUrgencyType providerUrgency,
             Double baseScore, SeverityType baseSeverity, Double threatScore, SeverityType threatSeverity,
@@ -200,15 +200,15 @@ public class CvssV4Data implements Serializable {
     @JsonProperty("modifiedSubsequentSystemConfidentiality")
     @JsonAlias("modifiedSubConfidentialityImpact")
     @JsonSetter(nulls = Nulls.SKIP)
-    private ModifiedCiaType modifiedSubConfidentialityImpact = ModifiedCiaType.NOT_DEFINED;
+    private ModifiedSubCType modifiedSubConfidentialityImpact = ModifiedSubCType.NOT_DEFINED;
     @JsonProperty("modifiedSubsequentSystemIntegrity")
     @JsonAlias("modifiedSubIntegrityImpact")
     @JsonSetter(nulls = Nulls.SKIP)
-    private ModifiedCiaType modifiedSubIntegrityImpact = ModifiedCiaType.NOT_DEFINED;
+    private ModifiedSubIaType modifiedSubIntegrityImpact = ModifiedSubIaType.NOT_DEFINED;
     @JsonProperty("modifiedSubsequentSystemAvailability")
     @JsonAlias("modifiedSubAvailabilityImpact")
     @JsonSetter(nulls = Nulls.SKIP)
-    private ModifiedCiaType modifiedSubAvailabilityImpact = ModifiedCiaType.NOT_DEFINED;
+    private ModifiedSubIaType modifiedSubAvailabilityImpact = ModifiedSubIaType.NOT_DEFINED;
     @JsonProperty("safety")
     @JsonAlias("Safety")
     @JsonSetter(nulls = Nulls.SKIP)
@@ -477,7 +477,7 @@ public class CvssV4Data implements Serializable {
      * @return modifiedSubConfidentialityImpact
      */
     @JsonProperty("modifiedSubConfidentialityImpact")
-    public ModifiedCiaType getModifiedSubConfidentialityImpact() {
+    public ModifiedSubCType getModifiedSubConfidentialityImpact() {
         return modifiedSubConfidentialityImpact;
     }
 
@@ -485,7 +485,7 @@ public class CvssV4Data implements Serializable {
      * @return modifiedSubIntegrityImpact
      */
     @JsonProperty("modifiedSubIntegrityImpact")
-    public ModifiedCiaType getModifiedSubIntegrityImpact() {
+    public ModifiedSubIaType getModifiedSubIntegrityImpact() {
         return modifiedSubIntegrityImpact;
     }
 
@@ -493,7 +493,7 @@ public class CvssV4Data implements Serializable {
      * @return modifiedSubAvailabilityImpact
      */
     @JsonProperty("modifiedSubAvailabilityImpact")
-    public ModifiedCiaType getModifiedSubAvailabilityImpact() {
+    public ModifiedSubIaType getModifiedSubAvailabilityImpact() {
         return modifiedSubAvailabilityImpact;
     }
 
@@ -650,15 +650,15 @@ public class CvssV4Data implements Serializable {
         }
         // (\/MSC:[XNLH])?(\/MSI:[XNLHS])?(\/MSA:[XNLHS])?(\/S:[XNP])?(\/AU:[XNY])?(\/R:[XAUI])?
         if (modifiedSubConfidentialityImpact != null) {
-            v.append("/MSC:").append(modifiedSubConfidentialityImpact == ModifiedCiaType.NOT_DEFINED ? "X"
+            v.append("/MSC:").append(modifiedSubConfidentialityImpact == ModifiedSubCType.NOT_DEFINED ? "X"
                     : modifiedSubConfidentialityImpact.value().charAt(0));
         }
         if (modifiedSubIntegrityImpact != null) {
-            v.append("/MSI:").append(modifiedSubIntegrityImpact == ModifiedCiaType.NOT_DEFINED ? "X"
+            v.append("/MSI:").append(modifiedSubIntegrityImpact == ModifiedSubIaType.NOT_DEFINED ? "X"
                     : modifiedSubIntegrityImpact.value().charAt(0));
         }
         if (modifiedSubAvailabilityImpact != null) {
-            v.append("/MSA:").append(modifiedSubAvailabilityImpact == ModifiedCiaType.NOT_DEFINED ? "X"
+            v.append("/MSA:").append(modifiedSubAvailabilityImpact == ModifiedSubIaType.NOT_DEFINED ? "X"
                     : modifiedSubAvailabilityImpact.value().charAt(0));
         }
         if (safety != null) {
@@ -1237,6 +1237,106 @@ public class CvssV4Data implements Serializable {
             return this.value;
         }
 
+    }
+
+    public enum ModifiedSubCType {
+
+        NEGLIGIBLE("NEGLIGIBLE"), LOW("LOW"), HIGH("HIGH"), NOT_DEFINED("NOT_DEFINED");
+
+        private final static Map<String, ModifiedSubCType> CONSTANTS = new HashMap<>();
+
+        static {
+            for (ModifiedSubCType c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        private final String value;
+
+        ModifiedSubCType(String value) {
+            this.value = value;
+        }
+
+        @JsonCreator
+        public static ModifiedSubCType fromValue(String value) {
+            // allow conversion from vector string
+            if (value != null && value.length() == 1) {
+                if ("x".equalsIgnoreCase(value)) {
+                    return NOT_DEFINED;
+                }
+                for (ModifiedSubCType t : values()) {
+                    if (t.value.startsWith(value.toUpperCase())) {
+                        return t;
+                    }
+                }
+            }
+            ModifiedSubCType constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonValue
+        public String value() {
+            return this.value;
+        }
+    }
+
+    public enum ModifiedSubIaType {
+
+        NEGLIGIBLE("NEGLIGIBLE"), LOW("LOW"), HIGH("HIGH"), SAFETY("SAFETY"), NOT_DEFINED("NOT_DEFINED");
+
+        private final static Map<String, ModifiedSubIaType> CONSTANTS = new HashMap<>();
+
+        static {
+            for (ModifiedSubIaType c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        private final String value;
+
+        ModifiedSubIaType(String value) {
+            this.value = value;
+        }
+
+        @JsonCreator
+        public static ModifiedSubIaType fromValue(String value) {
+            // allow conversion from vector string
+            if (value != null && value.length() == 1) {
+                if ("x".equalsIgnoreCase(value)) {
+                    return NOT_DEFINED;
+                }
+                for (ModifiedSubIaType t : values()) {
+                    if (t.value.startsWith(value.toUpperCase())) {
+                        return t;
+                    }
+                }
+            }
+            ModifiedSubIaType constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonValue
+        public String value() {
+            return this.value;
+        }
     }
 
     public enum SafetyType {

--- a/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/SerializationTest.java
+++ b/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/SerializationTest.java
@@ -41,7 +41,7 @@ class SerializationTest {
             json = r.lines().collect(Collectors.joining("\n"));
         }
         CveApiJson20 current = objectMapper.readValue(json, CveApiJson20.class);
-        assertEquals(2000, current.getVulnerabilities().size());
+        assertEquals(2001, current.getVulnerabilities().size());
 
         String serialized = objectMapper.writeValueAsString(current);
         CveApiJson20 hydrated = objectMapper.readValue(serialized, CveApiJson20.class);


### PR DESCRIPTION
Incorrectly used the wrong type for three fields that are rarely filled out in the NVD data. This resolves https://github.com/jeremylong/Open-Vulnerability-Project/issues/270

@marcelstoer thanks for suggesting adding the test case via #272 - I've included that here.